### PR TITLE
Burnt orange in place of the light surface, and SecurePuls

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ the contact email.
 src/
 ├─ app/                    routes — all static
 │  ├─ page.tsx             home
-│  ├─ securepulse/         product page
+│  ├─ securepuls/          product page
 │  ├─ kai/                 product page
 │  ├─ work/                selected work + commissioned systems
 │  ├─ contact/             contact form
@@ -110,7 +110,9 @@ Every user-facing string lives in `src/content/*.ts`. Components never contain c
 
 ### Design system
 
-Two surfaces, one token vocabulary. Each section declares `data-surface="ink" | "paper"`, and the semantic tokens (`--surface`, `--fg`, `--border`, `--accent`, …) resolve per surface — so `bg-surface text-fg` is correct on both without conditional classes.
+Two surfaces, one token vocabulary. Each section declares `data-surface="ink" | "ember"`, and the semantic tokens (`--surface`, `--fg`, `--border`, `--accent`, …) resolve per surface — so `bg-surface text-fg` is correct on both without conditional classes.
+
+Both surfaces are dark: near-black `ink`, and `ember`, a burnt orange struck from the brand hue. The alternating surface used to be a near-white sheet, and full-bleed at that size it read as a flash rather than as a change of register. The one place the two surfaces genuinely diverge is the accent — on ember the ground *is* brand orange, so the accent runs to the light end of the ramp and filled actions reverse out to cream.
 
 **Components must not contain raw hex.** ESLint enforces this. The single exception is `src/lib/raw-colors.ts`, for the two contexts that cannot read CSS variables: the `themeColor` meta tag and `next/og` image generation.
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,11 @@ const nextConfig: NextConfig = {
    * Those pages are gone, but the URLs may be linked externally (LinkedIn,
    * email signatures), so each one is permanently redirected to the closest
    * surviving destination rather than 404ing.
+   *
+   * /securepulse is the same story for a different reason: the product is
+   * spelled SecurePuls, and the route was corrected to match. Anything already
+   * pointing at the misspelling — links, the search index, a signature — keeps
+   * working.
    */
   async redirects() {
     return [
@@ -18,6 +23,7 @@ const nextConfig: NextConfig = {
       { source: "/projects", destination: "/work", permanent: true },
       { source: "/team", destination: "/", permanent: true },
       { source: "/careers", destination: "/contact", permanent: true },
+      { source: "/securepulse", destination: "/securepuls", permanent: true },
     ];
   },
 };

--- a/qa-mobile/audit.mjs
+++ b/qa-mobile/audit.mjs
@@ -38,7 +38,7 @@ const LANDSCAPE = [
   { name: "932x430", width: 932, height: 430, note: "large phone landscape" },
 ];
 
-const ROUTES = ["/", "/securepulse", "/kai", "/work", "/contact"];
+const ROUTES = ["/", "/securepuls", "/kai", "/work", "/contact"];
 
 /**
  * Safari's *small* viewport per device — the height actually visible with the

--- a/qa-mobile/crops.mjs
+++ b/qa-mobile/crops.mjs
@@ -9,8 +9,8 @@ const b = await webkit.launch();
 const shots = [
   ["/", "h1", "home-hero", 375, 812],
   ["/", "#products", "home-products", 390, 844],
-  ["/securepulse", 'div[role="img"][aria-label^="A draft finding"]', "sp-evidence", 375, 812],
-  ["/securepulse", "h1", "sp-hero", 375, 812],
+  ["/securepuls", 'div[role="img"][aria-label^="A draft finding"]', "sp-evidence", 375, 812],
+  ["/securepuls", "h1", "sp-hero", 375, 812],
   ["/work", "h1", "work-hero", 375, 812],
   ["/work", "dl", "work-figures", 375, 812],
   ["/", "footer", "footer", 390, 844],

--- a/qa-mobile/desktop.mjs
+++ b/qa-mobile/desktop.mjs
@@ -12,7 +12,7 @@ const BASE = process.env.BASE ?? "http://localhost:3100";
 const DIR = path.resolve(import.meta.dirname, process.argv[2] ?? "run", "desktop");
 fs.mkdirSync(DIR, { recursive: true });
 
-const ROUTES = ["/", "/securepulse", "/kai", "/work", "/contact"];
+const ROUTES = ["/", "/securepuls", "/kai", "/work", "/contact"];
 const SIZES = [
   { name: "1440x900", w: 1440, h: 900 },
   { name: "1920x1080", w: 1920, h: 1080 },
@@ -40,8 +40,8 @@ const CROPS = [
   ["/", "#products", "home-products"],
   ["/", "main > section:nth-of-type(2)", "home-thesis"],
   ["/", "main > section:nth-of-type(3)", "home-proof"],
-  ["/securepulse", "main > section:nth-of-type(1)", "sp-hero"],
-  ["/securepulse", 'div[role="img"][aria-label^="A draft finding"]', "sp-evidence"],
+  ["/securepuls", "main > section:nth-of-type(1)", "sp-hero"],
+  ["/securepuls", 'div[role="img"][aria-label^="A draft finding"]', "sp-evidence"],
   ["/kai", "main > section:nth-of-type(1)", "kai-hero"],
   ["/kai", "main > section:nth-of-type(2)", "kai-value"],
   ["/work", "main > section:nth-of-type(1)", "work-hero"],

--- a/qa-mobile/prod-smoke.mjs
+++ b/qa-mobile/prod-smoke.mjs
@@ -7,7 +7,7 @@
 import { chromium, webkit } from "@playwright/test";
 
 const BASE = process.argv[2] ?? "https://www.kaibresystems.com";
-const ROUTES = ["/", "/securepulse", "/kai", "/work", "/contact"];
+const ROUTES = ["/", "/securepuls", "/kai", "/work", "/contact"];
 
 const fail = [];
 const bad = (s) => {
@@ -142,7 +142,7 @@ async function run(engineName, browserType, viewport, isMobile) {
   } else {
     const page = await ctx.newPage();
     await page.goto(BASE + "/", { waitUntil: "networkidle" });
-    for (const label of ["SecurePulse", "kAI", "Work"]) {
+    for (const label of ["SecurePuls", "kAI", "Work"]) {
       const link = page.getByRole("navigation", { name: "Main" }).getByRole("link", { name: label, exact: true }).first();
       const href = await link.getAttribute("href");
       const r = await page.request.get(BASE + href);
@@ -177,6 +177,8 @@ async function routing() {
     ["/projects", "/work"],
     ["/team", "/"],
     ["/careers", "/contact"],
+    // The product is spelled SecurePuls; the route was corrected to match.
+    ["/securepulse", "/securepuls"],
   ]) {
     const r = await fetch(BASE + from, { redirect: "manual" });
     const loc = r.headers.get("location") ?? "";

--- a/qa-mobile/resize.mjs
+++ b/qa-mobile/resize.mjs
@@ -22,7 +22,7 @@ const IOS_UA =
   "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 " +
   "(KHTML, like Gecko) Version/18.5 Mobile/15E148 Safari/604.1";
 
-const ROUTES = ["/", "/securepulse", "/kai", "/work", "/contact"];
+const ROUTES = ["/", "/securepuls", "/kai", "/work", "/contact"];
 
 /** The matrix the brief requires. */
 const CASES = [

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -19,7 +19,7 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const TOPICS: Record<string, string> = {
-  securepulse: "SecurePulse",
+  securepuls: "SecurePuls",
   kai: "kAI",
   partnership: "A partnership",
   commissioned: "A commissioned system",

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
 
 export default function ContactPage() {
   return (
-    <Section surface="paper" space="flush" className="pb-16 pt-24 sm:pb-20 sm:pt-28">
+    <Section surface="ember" space="flush" className="pb-16 pt-24 sm:pb-20 sm:pt-28">
       <Container>
         {/* Two columns from `md`, not `lg`: a half-width tab on a 1080p
             monitor is around 960px, which stacked the form below the fold.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,10 +5,17 @@
    --------------------------------------------------------------------------
    Two surfaces, one token vocabulary.
 
-   Every section declares a surface via `data-surface="ink" | "paper"`.
+   Every section declares a surface via `data-surface="ink" | "ember"`.
    The semantic tokens below (--surface, --fg, --border, --accent, ...) are
    redefined per surface, so a component written once with `bg-surface
    text-fg` renders correctly on both without conditional classes.
+
+   Both surfaces are dark. The alternating surface was a near-white sheet, and
+   at the size these sections are — full-bleed, one after another — a visitor
+   scrolling from the near-black hero into one took the brightness change as a
+   flash rather than as a change of register. `ember` replaces it with a burnt
+   orange struck from the same hue as the brand ramp, so the two surfaces still
+   read as two distinct grounds without either of them being a light source.
 
    Components must never use raw hex. Use the semantic tokens.
    ========================================================================== */
@@ -55,11 +62,23 @@
   --color-ink-200: oklch(0.879 0.005 62);
   --color-ink-100: oklch(0.941 0.004 62);
 
-  /* --- Paper. Warm off-whites for light surfaces. ----------------------- */
-  --color-paper-50: oklch(0.984 0.004 78);
-  --color-paper-100: oklch(0.967 0.006 78);
-  --color-paper-200: oklch(0.928 0.008 78);
-  --color-paper-300: oklch(0.871 0.010 78);
+  /* --- Ember. The second surface: burnt orange, struck from the brand hue.
+     Same hue family as the ramp above, held two-thirds of the way down it and
+     pulled off its chroma peak — a full-bleed section is the largest field of
+     colour on the site, and the ramp's own saturation is tuned for marks a few
+     pixels wide, not for square metres of it. -------------------------- */
+  --color-ember-300: oklch(0.585 0.112 41);
+  --color-ember-400: oklch(0.512 0.112 41);
+  --color-ember-500: oklch(0.452 0.110 41);
+  --color-ember-600: oklch(0.404 0.104 41);
+  --color-ember-700: oklch(0.352 0.093 41);
+  --color-ember-800: oklch(0.300 0.080 41);
+
+  /* --- Cream. The type that sits on ember. Warm off-whites, carrying just
+     enough of the surface's own hue that they read as belonging to it. --- */
+  --color-cream-50: oklch(0.985 0.008 60);
+  --color-cream-200: oklch(0.905 0.024 52);
+  --color-cream-300: oklch(0.855 0.034 50);
 
   /* --- Single functional accent. Product-interface visuals only. -------- */
   --color-signal-400: oklch(0.712 0.062 218);
@@ -176,24 +195,34 @@
   --shadow-card: none;
 }
 
-[data-surface="paper"] {
-  --surface: var(--color-paper-50);
-  --surface-raised: oklch(1 0 0);
-  --surface-inset: var(--color-paper-100);
-  --fg: var(--color-ink-950);
-  --fg-muted: var(--color-ink-700);
-  --fg-subtle: var(--color-ink-600);
-  --border: var(--color-paper-200);
-  --border-strong: var(--color-paper-300);
-  --accent: var(--color-brand-700);
-  --accent-hover: var(--color-brand-800);
-  --accent-solid: var(--color-brand-700);
-  --accent-solid-hover: var(--color-brand-800);
-  --accent-contrast: oklch(1 0 0);
-  --accent-quiet: var(--color-brand-700);
-  --focus: var(--color-brand-700);
-  --success: var(--color-success-600);
-  --shadow-card: 0 1px 2px oklch(0.145 0.005 62 / 0.05), 0 8px 24px -12px oklch(0.145 0.005 62 / 0.12);
+/**
+ * The ember surface inverts one thing about the ink one: the accent cannot be
+ * the brand orange, because the ground already is. Orange-on-orange is a
+ * ~1.4:1 button. So on ember the accent runs to the *light* end of the same
+ * ramp for marks and text, and a filled action reverses out to cream with the
+ * darkest ember as its label. It is the same single accent, read against a
+ * different ground.
+ */
+[data-surface="ember"] {
+  --surface: var(--color-ember-600);
+  --surface-raised: var(--color-ember-500);
+  --surface-inset: var(--color-ember-700);
+  --fg: var(--color-cream-50);
+  --fg-muted: var(--color-cream-200);
+  --fg-subtle: var(--color-cream-300);
+  --border: var(--color-ember-400);
+  --border-strong: var(--color-ember-300);
+  --accent: var(--color-brand-200);
+  --accent-hover: var(--color-cream-50);
+  --accent-solid: var(--color-cream-50);
+  --accent-solid-hover: oklch(1 0 0);
+  --accent-contrast: var(--color-ember-800);
+  --accent-quiet: var(--color-brand-200);
+  --focus: var(--color-brand-200);
+  --success: var(--color-success-400);
+  /* Ember is dark enough that a black shadow reads as depth rather than dirt,
+     but it needs more of it than a white sheet did to register at all. */
+  --shadow-card: 0 1px 2px oklch(0.145 0.02 41 / 0.28), 0 10px 28px -14px oklch(0.145 0.02 41 / 0.55);
 }
 
 @theme inline {
@@ -413,7 +442,7 @@
   }
 }
 
-/* "Pulse" in SecurePulse, breathing. */
+/* "Puls" in SecurePuls, breathing. */
 @keyframes textBreathe {
   0%,
   100% {

--- a/src/app/kai/page.tsx
+++ b/src/app/kai/page.tsx
@@ -71,8 +71,8 @@ export default function KaiPage() {
         </Container>
       </Section>
 
-      {/* Value (light) */}
-      <Section surface="paper">
+      {/* Value (ember) */}
+      <Section surface="ember">
         <Container>
           <>
             <SectionHeader

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -101,8 +101,8 @@ export default function HomePage() {
         </Container>
       </Section>
 
-      {/* 3 — Production proof (light surface) ------------------------------ */}
-      <Section surface="paper">
+      {/* 3 — Production proof (ember surface) ------------------------------ */}
+      <Section surface="ember">
         <Container>
           <SectionHeader
             heading={PROOF.heading}
@@ -235,8 +235,8 @@ export default function HomePage() {
         </Container>
       </Section>
 
-      {/* 7 — How we work (light surface) ------------------------------------ */}
-      <Section surface="paper" id={HOW_WE_WORK.id}>
+      {/* 7 — How we work (ember surface) ------------------------------------ */}
+      <Section surface="ember" id={HOW_WE_WORK.id}>
         <Container>
           <>
             <SectionHeader

--- a/src/app/securepuls/page.tsx
+++ b/src/app/securepuls/page.tsx
@@ -13,7 +13,7 @@ import { Callout, WorkflowSteps } from "@/components/modules";
 import {
   AssessmentPanel,
   EvidenceLink,
-  SecurePulseName,
+  SecurePulsName,
   VisualFrame,
 } from "@/components/visuals";
 import {
@@ -25,22 +25,22 @@ import {
   SP_REPORT,
   SP_STATUS,
   SP_WORKFLOW,
-} from "@/content/securepulse";
+} from "@/content/securepuls";
 
 export const metadata: Metadata = {
-  title: "SecurePulse — Physical security assessment",
+  title: "SecurePuls — Physical security assessment",
   description:
-    "SecurePulse turns a physical security inspection into a structured, evidence-backed assessment: a checklist built for the site's emirate and sector, photo evidence captured on the walk, and findings a named assessor signs off.",
-  alternates: { canonical: "/securepulse" },
+    "SecurePuls turns a physical security inspection into a structured, evidence-backed assessment: a checklist built for the site's emirate and sector, photo evidence captured on the walk, and findings a named assessor signs off.",
+  alternates: { canonical: "/securepuls" },
   openGraph: {
-    title: "SecurePulse — Physical security assessment | Kaibre",
+    title: "SecurePuls — Physical security assessment | Kaibre",
     description:
-      "Structured, evidence-backed physical security assessments for UAE and Gulf sites. SecurePulse drafts; qualified people decide.",
-    url: "/securepulse",
+      "Structured, evidence-backed physical security assessments for UAE and Gulf sites. SecurePuls drafts; qualified people decide.",
+    url: "/securepuls",
   },
 };
 
-export default function SecurePulsePage() {
+export default function SecurePulsPage() {
   return (
     <>
       {/* Hero */}
@@ -54,7 +54,7 @@ export default function SecurePulsePage() {
           <div className="grid grid-cols-[minmax(0,1fr)] items-center gap-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)] lg:gap-16">
             <div>
               <p className="text-heading-1 font-medium text-fg">
-                <SecurePulseName animate />
+                <SecurePulsName animate />
                 <span className="ml-3 text-body font-normal text-fg-subtle">
                   {SP_HERO.category}
                 </span>
@@ -80,8 +80,8 @@ export default function SecurePulsePage() {
         </Container>
       </Section>
 
-      {/* Jurisdiction (light) */}
-      <Section surface="paper">
+      {/* Jurisdiction (ember) */}
+      <Section surface="ember">
         <Container>
           <>
             <SectionHeader
@@ -134,8 +134,8 @@ export default function SecurePulsePage() {
         </Container>
       </Section>
 
-      {/* Evidence discipline (light) — the product's core differentiator */}
-      <Section surface="paper">
+      {/* Evidence discipline (ember) — the product's core differentiator */}
+      <Section surface="ember">
         <Container>
           <>
             <SectionHeader

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -5,7 +5,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const lastModified = new Date();
   const routes: { path: string; priority: number }[] = [
     { path: "", priority: 1 },
-    { path: "/securepulse", priority: 0.9 },
+    { path: "/securepuls", priority: 0.9 },
     { path: "/work", priority: 0.8 },
     { path: "/kai", priority: 0.7 },
     { path: "/contact", priority: 0.6 },

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -41,8 +41,8 @@ export default function WorkPage() {
         </Container>
       </Section>
 
-      {/* Luxury commerce — the anonymised snapshot (light surface) */}
-      <Section surface="paper">
+      {/* Luxury commerce — the anonymised snapshot (ember surface) */}
+      <Section surface="ember">
         <Container>
           <SectionHeader
             heading={WORK_LUXURY.heading}
@@ -112,8 +112,8 @@ export default function WorkPage() {
         </Container>
       </Section>
 
-      {/* Commissioned systems (light) */}
-      <Section surface="paper">
+      {/* Commissioned systems (ember) */}
+      <Section surface="ember">
         <Container>
           <div className="grid gap-14 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)] lg:gap-20">
             <div>

--- a/src/components/brand/wordmark.tsx
+++ b/src/components/brand/wordmark.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
  *
  * Inlined from `full_logo_white.svg` with the editor metadata stripped and the
  * hardcoded `.cls-1` fill replaced by `currentColor`, so one asset works on
- * both the ink and paper surfaces.
+ * both the ink and ember surfaces.
  *
  * The group transform is load-bearing: the badge path is authored in a
  * different coordinate space from the lettering and must NOT be translated.

--- a/src/components/forms/contact-form.tsx
+++ b/src/components/forms/contact-form.tsx
@@ -19,8 +19,8 @@ import { cn } from "@/lib/utils";
 
 const TOPICS = [
   {
-    value: "securepulse",
-    label: "SecurePulse",
+    value: "securepuls",
+    label: "SecurePuls",
     placeholder:
       "e.g. We assess physical security across a dozen sites in Abu Dhabi and Dubai. Two senior assessors spend about three weeks per site walking it, writing findings, and producing the report — so each site gets covered once a year at best.",
   },

--- a/src/components/layout/site-footer.tsx
+++ b/src/components/layout/site-footer.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { Linkedin } from "lucide-react";
 import { FOOTER_GROUPS, SITE } from "@/content/site";
 import { KaibreWordmark } from "@/components/brand/wordmark";
-import { SecurePulseName } from "@/components/visuals";
+import { SecurePulsName } from "@/components/visuals";
 
 export function SiteFooter() {
   return (
@@ -44,8 +44,8 @@ export function SiteFooter() {
                       href={link.href}
                       className="inline-flex min-h-11 min-w-11 items-center text-small text-fg-muted transition-colors duration-150 hover:text-fg"
                     >
-                      {link.label === "SecurePulse" ? (
-                        <SecurePulseName animate />
+                      {link.label === "SecurePuls" ? (
+                        <SecurePulsName animate />
                       ) : (
                         link.label
                       )}

--- a/src/components/layout/site-header.tsx
+++ b/src/components/layout/site-header.tsx
@@ -109,16 +109,14 @@ export function SiteHeader() {
         data-scrolled="false"
         data-open={open ? "true" : "false"}
         className={cn(
-          // The header always carries its own ink surface. Pages that open on
-          // the light surface (/contact) would otherwise render light nav text
-          // on light paper — the bar has to be opaque to stay legible.
-          //
-          // Opaque in both scroll states, for the same reason. A frosted bar
-          // reads as intended over ink, where what shows through is the same
-          // near-black; over paper it let dark body text ghost up beside the
-          // wordmark, which is the one page the note above is about. A blur
-          // behind an opaque fill would only cost a compositing layer, so the
-          // scrolled state is now carried by its border alone.
+          // The header always carries its own ink surface, and it is opaque in
+          // both scroll states. A frosted bar reads as intended over ink, where
+          // what shows through is the same near-black; over the ember surface —
+          // which is what /contact opens on — it let the section's own copy
+          // ghost up beside the wordmark, and put the nav on a ground it was
+          // not coloured for. A blur behind an opaque fill would only cost a
+          // compositing layer, so the scrolled state is carried by its border
+          // alone.
           "fixed inset-x-0 top-0 z-50 border-b border-transparent bg-surface",
           "transition-[border-color] duration-200",
           "data-[scrolled=true]:border-border",

--- a/src/components/modules/index.tsx
+++ b/src/components/modules/index.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import Link from "next/link";
 import { ArrowUpRight, Check, Minus } from "lucide-react";
 import { Heading, Text } from "@/components/primitives";
-import { SecurePulseName } from "@/components/visuals";
+import { SecurePulsName } from "@/components/visuals";
 import { cn } from "@/lib/utils";
 
 /* ==========================================================================
@@ -97,7 +97,7 @@ export function ProductCard({
             {/* The product name is the thing being introduced, so it is the
                 largest type here — the tagline supports it, not the reverse. */}
             <h3 className="text-heading-1 font-medium text-fg">
-              {name === "SecurePulse" ? <SecurePulseName animate /> : name}
+              {name === "SecurePuls" ? <SecurePulsName animate /> : name}
             </h3>
             <p className="mt-1 text-small text-fg-subtle">{category}</p>
           </div>

--- a/src/components/primitives/index.tsx
+++ b/src/components/primitives/index.tsx
@@ -6,7 +6,7 @@ import { withBrand } from "@/components/visuals";
    Layout primitives
    ========================================================================== */
 
-type Surface = "ink" | "paper";
+type Surface = "ink" | "ember";
 
 interface SectionProps {
   children: ReactNode;

--- a/src/components/visuals/index.tsx
+++ b/src/components/visuals/index.tsx
@@ -204,14 +204,14 @@ export function PulseDot({
 }
 
 /* ==========================================================================
-   SecurePulseName — the product name, with its pulse
+   SecurePulsName — the product name, with its pulse
    --------------------------------------------------------------------------
-   "Pulse" carries the accent and breathes. Only the large instances animate;
+   "Puls" carries the accent and breathes. Only the large instances animate;
    in nav and footer the colour alone does the work, so the chrome stays
    still. The text remains one continuous string for screen readers.
    ========================================================================== */
 
-export function SecurePulseName({
+export function SecurePulsName({
   animate = true,
   delay = 0,
   className,
@@ -231,14 +231,14 @@ export function SecurePulseName({
           animate && "motion-safe:animate-[textBreathe_3.6s_ease-in-out_infinite]",
         )}
       >
-        Pulse
+        Puls
       </span>
     </span>
   );
 }
 
 /**
- * Renders any copy with "SecurePulse" carrying its accent.
+ * Renders any copy with "SecurePuls" carrying its accent.
  *
  * Body mentions take the colour but stay still — a page of breathing words
  * would be unreadable. Only the display instances animate.
@@ -247,9 +247,9 @@ export function SecurePulseName({
  * invisible, so CTA labels keep the plain name.
  */
 export function withBrand(text: string) {
-  if (!text.includes("SecurePulse")) return text;
-  return text.split("SecurePulse").flatMap((part, i) =>
-    i === 0 ? [part] : [<SecurePulseName key={i} delay={i * 420} />, part],
+  if (!text.includes("SecurePuls")) return text;
+  return text.split("SecurePuls").flatMap((part, i) =>
+    i === 0 ? [part] : [<SecurePulsName key={i} delay={i * 420} />, part],
   );
 }
 
@@ -323,7 +323,7 @@ export function Flow({
 }
 
 /* ==========================================================================
-   EvidenceLink — SecurePulse
+   EvidenceLink — SecurePuls
    --------------------------------------------------------------------------
    The product's differentiator in one picture: a finding, and the source it
    is tied back to. Placeholder text only — never real regulation.

--- a/src/content/home.ts
+++ b/src/content/home.ts
@@ -73,11 +73,11 @@ export const PRODUCTS = {
   body: "Two products in market, built on the same discipline. Both keep a person in the decision.",
   items: [
     {
-      name: "SecurePulse",
+      name: "SecurePuls",
       category: "Physical security assessment",
       headline: "Site assessments that show their working.",
-      body: "SecurePulse turns a physical security inspection into a structured assessment: a checklist built for the site's emirate and sector, photo evidence captured on the walk, and findings graded by severity. Every regulatory reference carries an evidence label, and a named assessor signs the report off.",
-      href: "/securepulse",
+      body: "SecurePuls turns a physical security inspection into a structured assessment: a checklist built for the site's emirate and sector, photo evidence captured on the walk, and findings graded by severity. Every regulatory reference carries an evidence label, and a named assessor signs the report off.",
+      href: "/securepuls",
       accent: true,
     },
     {

--- a/src/content/kai.ts
+++ b/src/content/kai.ts
@@ -90,7 +90,7 @@ export const KAI_FAQ = {
     },
     {
       q: "Does Kaibre build things other than kAI?",
-      a: "Yes. Kaibre is a software company — kAI is one of its products. We also build SecurePulse, and take on a small number of commissioned production systems each year.",
+      a: "Yes. Kaibre is a software company — kAI is one of its products. We also build SecurePuls, and take on a small number of commissioned production systems each year.",
     },
   ],
 } as const;

--- a/src/content/securepuls.ts
+++ b/src/content/securepuls.ts
@@ -1,11 +1,11 @@
 /**
- * SecurePulse page copy.
+ * SecurePuls page copy.
  *
- * Grounded in the SecurePulse product repositories (read-only inspection).
+ * Grounded in the SecurePuls product repositories (read-only inspection).
  * Every capability below is implemented today. Roadmap items are excluded.
  *
  * Hard constraints:
- *  - SecurePulse assesses PHYSICAL security in the UAE/GCC. Not infosec, not cyber.
+ *  - SecurePuls assesses PHYSICAL security in the UAE/GCC. Not infosec, not cyber.
  *  - No certification, accreditation, regulatory approval, or endorsement is claimed.
  *  - No named customers, institutions, or sectors-as-customers.
  *  - No metrics, percentages, or time savings.
@@ -15,17 +15,17 @@
 export const SP_HERO = {
   category: "Physical security assessment",
   headline: "Site assessments that show their working.",
-  body: "SecurePulse turns a physical security inspection into a structured, evidence-backed assessment. It builds the checklist for the site's emirate and sector, captures photo evidence on the walk, grades findings by severity, and produces a consulting-standard report that a named assessor signs off.",
-  cta: { label: "Talk to us about SecurePulse", href: "/contact?topic=securepulse" },
+  body: "SecurePuls turns a physical security inspection into a structured, evidence-backed assessment. It builds the checklist for the site's emirate and sector, captures photo evidence on the walk, grades findings by severity, and produces a consulting-standard report that a named assessor signs off.",
+  cta: { label: "Talk to us about SecurePuls", href: "/contact?topic=securepuls" },
 } as const;
 
 export const SP_JURISDICTION = {
   heading: "In the UAE, location decides the rulebook.",
   body: [
     "Physical security requirements in the UAE are set per emirate, not federally. A site in Dubai answers to a different authority stack than the same operator's site in Abu Dhabi or Sharjah, and critical infrastructure adds another layer again.",
-    "SecurePulse starts from the site's emirate and sector, and builds the assessment from there. Regulatory references are drawn from a maintained knowledge base rather than generated freely.",
+    "SecurePuls starts from the site's emirate and sector, and builds the assessment from there. Regulatory references are drawn from a maintained knowledge base rather than generated freely.",
   ],
-  note: "SecurePulse currently supports assessments for energy (oil and gas) sites and government buildings.",
+  note: "SecurePuls currently supports assessments for energy (oil and gas) sites and government buildings.",
 } as const;
 
 export const SP_WORKFLOW = {
@@ -39,7 +39,7 @@ export const SP_WORKFLOW = {
     {
       n: "02",
       title: "Generate the checklist",
-      body: "SecurePulse produces an assessment checklist organised across ten physical security domains and tailored to the site rather than pulled from a generic template.",
+      body: "SecurePuls produces an assessment checklist organised across ten physical security domains and tailored to the site rather than pulled from a generic template.",
     },
     {
       n: "03",
@@ -80,7 +80,7 @@ export const SP_EVIDENCE = {
   heading: "Every regulatory claim carries its confidence.",
   body: [
     "UAE physical security guidance is unevenly published. Some requirements are set out in enacted law; some are only visible through approved installers and industry sources; some are genuinely unresolved.",
-    "SecurePulse labels each regulatory reference with the strength of the evidence behind it, and it is not permitted to present an unresolved item as a probable requirement. Where the answer is not established, the assessment says so and escalates it to the competent authority.",
+    "SecurePuls labels each regulatory reference with the strength of the evidence behind it, and it is not permitted to present an unresolved item as a probable requirement. Where the answer is not established, the assessment says so and escalates it to the competent authority.",
   ],
   labels: [
     {
@@ -103,16 +103,16 @@ export const SP_EVIDENCE = {
 } as const;
 
 export const SP_HUMAN = {
-  heading: "SecurePulse drafts. People decide.",
+  heading: "SecurePuls drafts. People decide.",
   body: [
-    "SecurePulse is professional advisory tooling. It is not a regulatory audit, a legal opinion, or a certification, and it does not replace a qualified security assessor.",
+    "SecurePuls is professional advisory tooling. It is not a regulatory audit, a legal opinion, or a certification, and it does not replace a qualified security assessor.",
     "Findings are drafts until a lead assessor and a reviewer accept them. Every report carries a named sign-off, records that it is a point-in-time assessment, and instructs the reader to verify regulatory references with the competent authority.",
   ],
 } as const;
 
 export const SP_REPORT = {
   heading: "A report a consultant would recognise.",
-  body: "SecurePulse produces the sections an assessment report is expected to contain, in a consistent structure, exportable to PDF or Word.",
+  body: "SecurePuls produces the sections an assessment report is expected to contain, in a consistent structure, exportable to PDF or Word.",
   sections: [
     "Assessment summary and risk scorecard",
     "Findings by domain",
@@ -127,7 +127,7 @@ export const SP_REPORT = {
 } as const;
 
 export const SP_STATUS = {
-  heading: "Where SecurePulse is today",
-  body: "SecurePulse is in active development and demonstration with organisations in the UAE and the wider Gulf. If you assess physical security for regulated or high-consequence sites, we would like to show you the current build and hear where it breaks.",
-  cta: { label: "Talk to us about SecurePulse", href: "/contact?topic=securepulse" },
+  heading: "Where SecurePuls is today",
+  body: "SecurePuls is in active development and demonstration with organisations in the UAE and the wider Gulf. If you assess physical security for regulated or high-consequence sites, we would like to show you the current build and hear where it breaks.",
+  cta: { label: "Talk to us about SecurePuls", href: "/contact?topic=securepuls" },
 } as const;

--- a/src/content/site.ts
+++ b/src/content/site.ts
@@ -32,8 +32,8 @@ export const SITE = {
 export const NAV = {
   products: [
     {
-      label: "SecurePulse",
-      href: "/securepulse",
+      label: "SecurePuls",
+      href: "/securepuls",
       note: "Physical security assessment",
     },
     { label: "kAI", href: "/kai", note: "Outbound voice agent" },
@@ -49,7 +49,7 @@ export const FOOTER_GROUPS = [
   {
     title: "Products",
     links: [
-      { label: "SecurePulse", href: "/securepulse" },
+      { label: "SecurePuls", href: "/securepuls" },
       { label: "kAI", href: "/kai" },
     ],
   },

--- a/tests/mobile.spec.ts
+++ b/tests/mobile.spec.ts
@@ -13,7 +13,7 @@ import { expect, test, type Page } from "@playwright/test";
    visitor can never reach — plus the routine mobile invariants around them.
    ========================================================================== */
 
-const ROUTES = ["/", "/securepulse", "/kai", "/work", "/contact"] as const;
+const ROUTES = ["/", "/securepuls", "/kai", "/work", "/contact"] as const;
 
 /**
  * The required matrix. `small` is Safari's *small* viewport for the device —
@@ -321,8 +321,8 @@ test.describe("layout", () => {
 
   test("the fixed header stays opaque over both surfaces", async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
-    // /contact opens on the light surface, where anything showing through the
-    // bar is dark body text against the wordmark rather than more near-black.
+    // /contact opens on the ember surface, where anything showing through the
+    // bar is burnt orange against the wordmark rather than more near-black.
     for (const route of ["/contact", "/"]) {
       await page.goto(route);
       for (const scroll of [0, 300]) {
@@ -442,6 +442,8 @@ test.describe("navigation", () => {
       ["/projects", "/work"],
       ["/team", "/"],
       ["/careers", "/contact"],
+      // The product is spelled SecurePuls; the old route must not 404.
+      ["/securepulse", "/securepuls"],
     ]) {
       await page.goto(from);
       await expect(page).toHaveURL(new RegExp(`${to.replace("/", "\\/")}$`));

--- a/tests/text-resize.spec.ts
+++ b/tests/text-resize.spec.ts
@@ -16,7 +16,7 @@ import { expect, test, type Page } from "@playwright/test";
      - nothing is clipped, and the page never scrolls horizontally at 320px.
    ========================================================================== */
 
-const ROUTES = ["/", "/securepulse", "/kai", "/work", "/contact"] as const;
+const ROUTES = ["/", "/securepuls", "/kai", "/work", "/contact"] as const;
 
 const CASES = [
   { w: 320, h: 568, zoom: 100 },


### PR DESCRIPTION
Founder feedback, both parts.

## The white sections are gone

The alternating surface was a near-white sheet. Full-bleed and one section after another, scrolling out of the near-black hero into it read as a flash rather than as a change of register.

`ember` replaces it: `#763116`, struck from the brand hue (41) — the same family as `#BB4400`, held two-thirds of the way down the ramp and pulled off its chroma peak, because a full-bleed section is the largest field of colour on the site and the ramp's saturation is tuned for marks a few pixels wide. Type on it is a warm cream carrying a little of the ground's own hue. The surface is renamed from `paper` to `ember` throughout rather than left holding a name it no longer describes.

The one place the two surfaces genuinely diverge is the accent. On ember the ground already *is* brand orange, so an orange fill measures 1.4:1 — an invisible button. The accent runs to the light end of the same ramp for text and marks, and filled actions reverse out to cream with the darkest ember as their label. It is still one accent, read against a different ground.

Every pair clears WCAG AA, measured against each element's real painted background:

| | ratio |
|---|---|
| body on ember | 9.0:1 |
| muted | 7.1:1 |
| subtle | 6.1:1 |
| accent | 5.9:1 |
| filled-button label | 13.4:1 |
| focus ring | 5.9:1 |

The ink surface is untouched.

## SecurePuls, not SecurePulse

Corrected in the copy, in the component that carries the name's accent (`Puls` is what breathes now), in the contact form's topic and the email subject it produces, and in the route.

`/securepulse` redirects permanently to `/securepuls`, so existing links, signatures and the search index keep working. Both the E2E suite and the production smoke test assert that redirect.

## Verification

- `pnpm build` clean from a wiped `.next`; `typecheck` and `lint` clean.
- **242/242 E2E pass** — real WebKit and Chromium, full phone matrix, full 200%-text matrix.
- Scripted contrast audit over every text node on all five routes, resolving each element's actual painted background: zero failures.
- All five routes eyeballed at desktop and phone widths.

## Known, not addressed

- A 4.47:1 near-miss on `/securepuls` — the brand accent on the **ink** surface, pre-existing and untouched here. Fixing it means moving the dark-surface orange, which is a separate decision.
- Input-field borders on ember measure 1.59:1 against the surface. Weak, but that is parity with the ink surface (1.6:1) and better than the old white one (1.06:1). Raising it would make every hairline on the site louder.

---

**Follow-up:** the fields were then taken white with near-black type in #9, which supersedes the last bullet above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
