### PR TITLE
White entry fields on the ember surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ Every user-facing string lives in `src/content/*.ts`. Components never contain c
 
 Two surfaces, one token vocabulary. Each section declares `data-surface="ink" | "ember"`, and the semantic tokens (`--surface`, `--fg`, `--border`, `--accent`, …) resolve per surface — so `bg-surface text-fg` is correct on both without conditional classes.
 
-Both surfaces are dark: near-black `ink`, and `ember`, a burnt orange struck from the brand hue. The alternating surface used to be a near-white sheet, and full-bleed at that size it read as a flash rather than as a change of register. The one place the two surfaces genuinely diverge is the accent — on ember the ground *is* brand orange, so the accent runs to the light end of the ramp and filled actions reverse out to cream.
+Both surfaces are dark: near-black `ink`, and `ember`, a burnt orange struck from the brand hue. The alternating surface used to be a near-white sheet, and full-bleed at that size it read as a flash rather than as a change of register. The one place the two surfaces genuinely diverge is the accent — on ember the ground *is* brand orange, so the accent runs to the light end of the ramp and filled actions reverse out to white with a near-black label.
+
+Entry fields are tokenised apart from the surface (`--field`, `--field-fg`, `--field-placeholder`, `--field-border`, `--field-border-focus`). A card and a text input want the same treatment on ink and emphatically do not on ember: a section is scenery, but a field is a target, and tinted the same as the ground it sits on its edge goes soft and the form reads as one block. On ember a field is a white sheet with near-black type.
 
 **Components must not contain raw hex.** ESLint enforces this. The single exception is `src/lib/raw-colors.ts`, for the two contexts that cannot read CSS variables: the `themeColor` meta tag and `next/og` image generation.
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -193,15 +193,23 @@
   --focus: var(--color-brand-400);
   --success: var(--color-success-400);
   --shadow-card: none;
+  /* An entry field is the one surface a visitor is asked to work *inside* of,
+     so it is tokenised apart from `surface-raised` — a card and a text input
+     want the same treatment on ink and emphatically do not on ember. */
+  --field: var(--color-ink-900);
+  --field-fg: var(--color-ink-100);
+  --field-placeholder: var(--color-ink-400);
+  --field-border: var(--color-ink-800);
+  --field-border-focus: var(--color-brand-500);
 }
 
 /**
  * The ember surface inverts one thing about the ink one: the accent cannot be
  * the brand orange, because the ground already is. Orange-on-orange is a
  * ~1.4:1 button. So on ember the accent runs to the *light* end of the same
- * ramp for marks and text, and a filled action reverses out to cream with the
- * darkest ember as its label. It is the same single accent, read against a
- * different ground.
+ * ramp for marks and text, and a filled action reverses out to white with a
+ * near-black label. It is the same single accent, read against a different
+ * ground.
  */
 [data-surface="ember"] {
   --surface: var(--color-ember-600);
@@ -214,15 +222,33 @@
   --border-strong: var(--color-ember-300);
   --accent: var(--color-brand-200);
   --accent-hover: var(--color-cream-50);
-  --accent-solid: var(--color-cream-50);
-  --accent-solid-hover: oklch(1 0 0);
-  --accent-contrast: var(--color-ember-800);
+  /* The same white as a field, deliberately: a filled action and an entry box
+     are the two light objects on the surface, and two near-identical whites
+     read as a mistake rather than as a distinction. */
+  --accent-solid: oklch(1 0 0);
+  --accent-solid-hover: var(--color-cream-200);
+  --accent-contrast: var(--color-ink-950);
   --accent-quiet: var(--color-brand-200);
   --focus: var(--color-brand-200);
   --success: var(--color-success-400);
   /* Ember is dark enough that a black shadow reads as depth rather than dirt,
      but it needs more of it than a white sheet did to register at all. */
   --shadow-card: 0 1px 2px oklch(0.145 0.02 41 / 0.28), 0 10px 28px -14px oklch(0.145 0.02 41 / 0.55);
+
+  /**
+   * Entry fields are the one thing on ember that stays a light sheet, and the
+   * reason is the opposite of the one that took the light surface away. A
+   * full-bleed section is scenery — the eye passes over it. A field is a
+   * target: it has to say where it begins and ends, hold the caret, and show
+   * typed characters at speed. Tinted the same as the ground it sits on, the
+   * edge went soft and the whole form read as one brown block. It is a few
+   * hundred square pixels rather than a screenful, so it does not flash.
+   */
+  --field: oklch(1 0 0);
+  --field-fg: var(--color-ink-950);
+  --field-placeholder: var(--color-ink-600);
+  --field-border: var(--color-ink-300);
+  --field-border-focus: var(--color-brand-600);
 }
 
 @theme inline {
@@ -234,6 +260,11 @@
   --color-fg-subtle: var(--fg-subtle);
   --color-border: var(--border);
   --color-border-strong: var(--border-strong);
+  --color-field: var(--field);
+  --color-field-fg: var(--field-fg);
+  --color-field-placeholder: var(--field-placeholder);
+  --color-field-border: var(--field-border);
+  --color-field-border-focus: var(--field-border-focus);
   --color-accent: var(--accent);
   --color-accent-hover: var(--accent-hover);
   --color-accent-solid: var(--accent-solid);

--- a/src/components/forms/contact-form.tsx
+++ b/src/components/forms/contact-form.tsx
@@ -62,9 +62,15 @@ interface Fields {
   work: string;
 }
 
+/**
+ * Fields carry their own tokens rather than the section's surface ones. On
+ * ember that resolves to a white sheet with near-black type: a field is a
+ * target rather than scenery, and tinted the same as the ground it sits on its
+ * edge went soft and the form read as one block.
+ */
 const FIELD =
-  "w-full rounded-control border border-border bg-surface-raised px-4 py-3 text-body text-fg " +
-  "placeholder:text-fg-subtle transition-colors duration-150 focus:border-accent";
+  "w-full rounded-control border border-field-border bg-field px-4 py-3 text-body text-field-fg " +
+  "placeholder:text-field-placeholder transition-colors duration-150 focus:border-field-border-focus";
 
 function isEmail(value: string) {
   return /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(value);
@@ -232,9 +238,12 @@ export function ContactForm() {
               </option>
             ))}
           </select>
+          {/* Sits inside the field, so it takes the field's ink, not the
+              section's — on ember the surface tone is a near-invisible
+              cream-on-white. */}
           <ChevronDown
             aria-hidden
-            className="pointer-events-none absolute right-4 top-1/2 size-4 -translate-y-1/2 text-fg-subtle"
+            className="pointer-events-none absolute right-4 top-1/2 size-4 -translate-y-1/2 text-field-placeholder"
           />
         </div>
       </Field>


### PR DESCRIPTION
Follow-up to #8, from the same round of feedback: the form was hard to read against the new surface.

## What changed

Tinting the fields with the surface they sit on was the wrong read of the surface change. A full-bleed section is scenery — the eye passes over it, and taking the glare out of it was the point. A field is the opposite: it is a target, it has to say where it begins and ends, hold a caret, and show typed characters at speed. Brown-on-brown softened every edge and the form read as one block.

Fields are now tokenised apart from `surface-raised`:

- `--field`
- `--field-fg`
- `--field-placeholder`
- `--field-border`
- `--field-border-focus`

A card and a text input want the same treatment on ink and emphatically do not on ember. **On ember a field is a white sheet with near-black type; on ink nothing changes.** A few hundred square pixels is not a screenful, so this does not bring the flash back.

Filled actions follow: white rather than cream, so the two light objects on the surface are the same white instead of two that differ by an amount no one can name, and their label is near-black.

The select chevron moves off the section's foreground token onto the field's, since it sits inside the field — on ember it was cream on white.

## Measured on /contact

| | ratio |
|---|---|
| field text | 19.8:1 |
| placeholder | 8.5:1 |
| field against the surface | 9.5:1 |
| focus border against the field | 5.3:1 |
| focus ring against the surface | 5.9:1 |
| filled-button label | 19.8:1 |

## Verification

- `pnpm build` clean; `typecheck` and `lint` clean.
- **242/242 E2E pass** — real WebKit and Chromium, full phone matrix, full 200%-text matrix.
- Scripted contrast audit over every text node **and placeholder** on the page, resolving each element's actual painted background: zero failures. Focus states measured under real keyboard focus rather than programmatic `.focus()`, which does not engage `:focus` in an unfocused window.

## Known, not addressed

The CTA aura is a little more visible behind a white button than it was behind an orange one. It is the site-wide primary-action treatment, so toning it down is a change to every CTA rather than to this one — say the word if you want that as its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
