### PR TITLE
Sharpen the SecurePuls Indonesia experience for the executive read

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,14 +127,21 @@ compact localised footer. `<html lang>` is corrected per locale by an inline
 script on load and a `LangSync` effect on soft navigation; the two pages name
 each other in `hreflang` alternates and the sitemap.
 
-Claim discipline is stricter here than on the rest of the site: no Indonesian
-regulator, framework or law is named anywhere on the pair until support for it
-is verified — the requirement sets an assessment runs against are described as
-configured per engagement. `tests/indonesia.spec.ts` enforces this, along with
-linguistic purity in both directions (no stray English on the Indonesian route
-beyond an approved-terms list, and vice versa), toggle behaviour, locale
-metadata, and the localised contact form. The general layout, text-resize and
-runtime suites include both routes in their matrices.
+Claim discipline on the pair, founder-approved: OJK, Bank Indonesia and
+insurance-sector requirements may be named as **target corpus categories
+configured per engagement** — never as approving, endorsing, or completely
+covered, and no specific instrument (POJK/SEOJK, UU PDP) or non-target
+regulator is named. The ~30-minute figure is founder/practitioner-supplied
+evidence from the working SecurePuls workflow reviewed by a senior regulatory
+lawyer; it always travels qualified ("about", "for a configured assessment",
+plus the scope/volume/configuration note) and never as an SLA. Illustrative
+figures appear only inside mockups tagged "Illustrative", and the vocabulary
+is "review-ready", never "audit-ready". `tests/indonesia.spec.ts` enforces all
+of this — plus scan-level presence of the load-bearing concepts, linguistic
+purity in both directions (no stray English on the Indonesian route beyond an
+approved-terms list, and vice versa), toggle behaviour, locale metadata, and
+the localised contact form. The general layout, text-resize and runtime suites
+include both routes in their matrices.
 
 ### Copy
 

--- a/qa-mobile/prod-smoke.mjs
+++ b/qa-mobile/prod-smoke.mjs
@@ -40,14 +40,20 @@ const FORBIDDEN_CLAIMS = [
   { re: /\b\d{1,3}\s?%/, why: "percentage metric" },
   { re: /\b\d+x\s+(more|faster|better|higher|increase)/i, why: "multiplier claim" },
   { re: /\b(trusted by|used by)\s+\d+/i, why: "customer count" },
-  /* The Indonesian pages must hold the same discipline in Bahasa Indonesia,
-     and no page may name an Indonesian regulator or framework until support
-     for it is verified. */
+  /* The Indonesian pages must hold the same discipline in Bahasa Indonesia.
+     OJK / Bank Indonesia / insurance-sector requirements may be named as
+     target corpus categories configured per engagement (founder-approved
+     framing) — but never as approving, endorsing, or completely covered, and
+     no specific instrument (POJK/SEOJK, UU PDP) or non-target regulator may
+     be named. */
   { re: /\b(tersertifikasi|terakreditasi|kepatuhan otomatis)\b/i, why: "certification claim (id)" },
-  { re: /\bdisetujui oleh\s+(OJK|Bank Indonesia|regulator)\b/i, why: "endorsement claim (id)" },
+  { re: /\bdisetujui\s+(?:oleh\s+)?(OJK|Bank Indonesia|regulator)\b/i, why: "endorsement claim (id)" },
   { re: /\bmenjamin\s+kepatuhan\b/i, why: "compliance guarantee (id)" },
-  { re: /\b(OJK|PPATK|POJK|SEOJK|Kominfo)\b/, why: "named Indonesian regulator/framework" },
-  { re: /\bBank Indonesia\b/, why: "named Indonesian regulator" },
+  { re: /\b(?:OJK|Bank Indonesia)[- ]approved\b/i, why: "regulator-approval claim" },
+  { re: /\b(?:approved|endorsed|licensed)\s+by\s+(?:OJK|Bank Indonesia)\b/i, why: "regulator-approval claim" },
+  { re: /\b(?:complete|full)\s+coverage\b/i, why: "complete-coverage claim" },
+  { re: /\bcakupan\s+(?:penuh|lengkap|menyeluruh)\b/i, why: "complete-coverage claim (id)" },
+  { re: /\b(PPATK|POJK|SEOJK|Kominfo)\b/, why: "named regulator/instrument outside the corpus framing" },
   { re: /\b(UU\s?PDP|PDP Law)\b/i, why: "named Indonesian regulation" },
 ];
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -183,11 +183,15 @@
   --border-strong: var(--color-ink-700);
   --accent: var(--color-brand-500);
   --accent-hover: var(--color-brand-400);
-  /* Solid fills are a step darker than accent text so white type clears 4.5:1
-     on them. Keeping the two separate means accent TEXT stays bright enough to
-     read on ink, instead of both being dragged toward one compromise value. */
-  --accent-solid: var(--color-brand-700);
-  --accent-solid-hover: var(--color-brand-600);
+  /* Solid fills are two steps darker than accent text so white type clears
+     4.5:1 with room to spare. Keeping the two separate means accent TEXT stays
+     bright enough to read on ink, instead of both being dragged toward one
+     compromise value. brand-800 rather than brand-700 came back from the
+     founders: at button size the brighter fill read as consumer-SaaS orange,
+     and the deeper burnt tone is the register an enterprise compliance buyer
+     expects. White on brand-800 is ~9:1. */
+  --accent-solid: var(--color-brand-800);
+  --accent-solid-hover: var(--color-brand-700);
   --accent-contrast: oklch(1 0 0);
   --accent-quiet: var(--color-brand-300);
   --focus: var(--color-brand-400);
@@ -222,9 +226,11 @@
   --border-strong: var(--color-ember-300);
   --accent: var(--color-brand-200);
   --accent-hover: var(--color-cream-50);
-  /* The same white as a field, deliberately: a filled action and an entry box
-     are the two light objects on the surface, and two near-identical whites
-     read as a mistake rather than as a distinction. */
+  /* The filled action stays pure white while fields sit on cream-200: they
+     are the two light objects on the surface, and a full step of lightness
+     between them reads as a hierarchy — the action is the brightest thing on
+     the page, the field is the paper you write on. (Two *near-identical*
+     whites would read as a mistake; these are deliberately apart.) */
   --accent-solid: oklch(1 0 0);
   --accent-solid-hover: var(--color-cream-200);
   --accent-contrast: var(--color-ink-950);
@@ -241,13 +247,18 @@
    * full-bleed section is scenery — the eye passes over it. A field is a
    * target: it has to say where it begins and ends, hold the caret, and show
    * typed characters at speed. Tinted the same as the ground it sits on, the
-   * edge went soft and the whole form read as one brown block. It is a few
-   * hundred square pixels rather than a screenful, so it does not flash.
+   * edge went soft and the whole form read as one brown block.
+   *
+   * Warm cream rather than pure white, from founder review: a #fff sheet on a
+   * dark page read as a flash. cream-200 keeps the field unmistakably the
+   * light, interactive object on the surface while sitting in the site's own
+   * warm range — near-black type on it still clears 10:1, and the placeholder
+   * (ink-600) clears 4.5:1.
    */
-  --field: oklch(1 0 0);
+  --field: var(--color-cream-200);
   --field-fg: var(--color-ink-950);
   --field-placeholder: var(--color-ink-600);
-  --field-border: var(--color-ink-300);
+  --field-border: var(--color-ink-400);
   --field-border-focus: var(--color-brand-600);
 }
 
@@ -442,16 +453,18 @@
   }
 }
 
-/* Behind a primary action: a soft bed of light that breathes. */
+/* Behind a primary action: a soft bed of light that breathes. Peak held low
+   deliberately — at 0.5 the halo read as consumer-app neon against the
+   restrained enterprise register the founders asked for. */
 @keyframes glowButton {
   0%,
   100% {
-    opacity: 0.14;
+    opacity: 0.1;
     transform: scale(0.98);
   }
   50% {
-    opacity: 0.5;
-    transform: scale(1.06);
+    opacity: 0.3;
+    transform: scale(1.05);
   }
 }
 
@@ -461,10 +474,10 @@
 @keyframes auraRing {
   0% {
     box-shadow: 0 0 0 0 var(--accent);
-    opacity: 0.55;
+    opacity: 0.4;
   }
   70% {
-    box-shadow: 0 0 0 16px var(--accent);
+    box-shadow: 0 0 0 12px var(--accent);
     opacity: 0;
   }
   100% {
@@ -473,21 +486,22 @@
   }
 }
 
-/* "Puls" in SecurePuls, breathing. */
+/* "Puls" in SecurePuls, breathing. The glow is a suggestion rather than a
+   sign: the triple 40px bloom of the first pass read as neon on an
+   enterprise page, so the peak is now one tight halo. */
 @keyframes textBreathe {
   0%,
   100% {
     /* The trough has to stay legible — below ~0.45 the name reads as
        disappearing rather than breathing. */
-    opacity: 0.5;
+    opacity: 0.55;
     text-shadow: 0 0 0 transparent;
   }
   50% {
     opacity: 1;
     text-shadow:
-      0 0 6px var(--accent),
-      0 0 20px var(--accent),
-      0 0 40px var(--accent);
+      0 0 4px var(--accent),
+      0 0 14px var(--accent);
   }
 }
 

--- a/src/components/indonesia/experience.tsx
+++ b/src/components/indonesia/experience.tsx
@@ -2,21 +2,25 @@ import {
   Card,
   Container,
   Heading,
-  Prose,
+  Note,
   Section,
   SectionHeader,
   Text,
 } from "@/components/primitives";
 import { Button, ArrowLink } from "@/components/primitives/button";
-import { Callout, FitList, WorkflowSteps } from "@/components/modules";
-import { StatusList, VisualFrame, withBrand } from "@/components/visuals";
+import { Callout } from "@/components/modules";
+import { VisualFrame, withBrand } from "@/components/visuals";
 import { IndoHeader } from "@/components/indonesia/chrome";
 import { IndoFooter } from "@/components/indonesia/footer";
 import { IndoContactForm } from "@/components/indonesia/contact-form";
 import { LangSync } from "@/components/indonesia/lang-sync";
 import {
-  DeliverableList,
-  InputList,
+  AssessmentOverview,
+  FlowCompare,
+  IconList,
+  RemediationTable,
+  ReportPreview,
+  StageGrid,
   TraceChain,
 } from "@/components/indonesia/visuals";
 import type { IndoContent } from "@/content/indonesia/types";
@@ -24,11 +28,12 @@ import type { IndoContent } from "@/content/indonesia/types";
 /**
  * The SecurePuls Indonesia experience — one component, two dictionaries.
  *
- * Section order follows the executive reading test: what it is and who it is
- * for (hero), what goes in and what comes out, the workflow, why a finding
- * can be defended (traceability), what changes against the manual process,
- * who decides, who it serves, where it runs, and how to start a conversation.
- * Nothing conceptual sits ahead of the concrete deliverables.
+ * Ordered for a two-to-three-minute executive read: outcome and time
+ * compression in the headline; inputs and deliverables before any concept;
+ * the workflow in four icon-led stages; then the depth — gap analysis with
+ * its evidence trail, the remediation plan and report a buyer actually
+ * receives, the before/after, who decides, who it serves, and what an
+ * Indonesian deployment includes. One conversion path at the end.
  *
  * The page renders its own chrome: the company-site header is English, and an
  * Indonesian-language page must not open under it.
@@ -60,16 +65,16 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
       <IndoHeader content={c} />
 
       <main id="main" tabIndex={-1}>
-        {/* Hero — what it is, who it is for, the primary outcome. */}
+        {/* Hero — outcome, time compression, and what the software is. */}
         <Section surface="ink" space="flush" className="pb-20 pt-14 sm:pb-24 sm:pt-20">
           <Container>
             <div className="grid grid-cols-[minmax(0,1fr)] items-center gap-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)] lg:gap-16">
               <div>
-                <p className="text-body text-fg-subtle">{c.hero.audience}</p>
-                <Heading level={1} size="display-1" className="mt-4 max-w-[18ch]">
+                <p className="max-w-[52ch] text-body text-fg-subtle">{c.hero.kicker}</p>
+                <Heading level={1} size="display-1" className="mt-4 max-w-[26ch]">
                   {c.hero.headline}
                 </Heading>
-                <Text size="lead" className="mt-6 max-w-[56ch]">
+                <Text size="lead" className="mt-6 max-w-[58ch]">
                   {c.hero.body}
                 </Text>
                 <div className="mt-9 flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-7">
@@ -78,15 +83,14 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
                     {c.hero.secondary.label}
                   </ArrowLink>
                 </div>
+                <p className="mt-5 max-w-[52ch] text-fine text-fg-subtle">
+                  {c.hero.timingNote}
+                </p>
               </div>
 
               <div>
                 <VisualFrame label={c.hero.panel.alt}>
-                  <StatusList
-                    caption={c.hero.panel.caption}
-                    rows={c.hero.panel.rows}
-                    footnote={c.hero.panel.footnote}
-                  />
+                  <AssessmentOverview panel={c.hero.panel} />
                 </VisualFrame>
                 <p className="mt-3 text-fine text-fg-subtle">
                   {c.hero.illustrationNote}
@@ -96,32 +100,32 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
           </Container>
         </Section>
 
-        {/* In / out — the concrete deliverables, before any concept. */}
+        {/* In / out — the concrete inputs and deliverables. */}
         <Section surface="ember">
           <Container>
             <SectionHeader heading={c.inOut.heading} />
             <div className="mt-12 grid grid-cols-[minmax(0,1fr)] gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.15fr)] lg:gap-14">
               <div>
-                <h3 className="text-heading-2 text-fg">{withBrand(c.inOut.give.title)}</h3>
-                <InputList items={c.inOut.give.items} className="mt-5" />
+                <h3 className="text-heading-2 text-fg">{withBrand(c.inOut.reads.title)}</h3>
+                <IconList items={c.inOut.reads.items} className="mt-6" />
               </div>
               <Card className="p-7 sm:p-8">
-                <h3 className="text-heading-2 text-fg">{withBrand(c.inOut.get.title)}</h3>
-                <DeliverableList items={c.inOut.get.items} className="mt-5" />
+                <h3 className="text-heading-2 text-fg">{withBrand(c.inOut.produces.title)}</h3>
+                <IconList items={c.inOut.produces.items} emphasis className="mt-6" />
               </Card>
             </div>
           </Container>
         </Section>
 
-        {/* Workflow — six steps, glanceable from the titles alone. */}
+        {/* Workflow — four stages, icon-led, glanceable. */}
         <Section surface="ink" id="workflow">
           <Container>
             <SectionHeader heading={c.workflow.heading} />
-            <WorkflowSteps steps={c.workflow.steps} />
+            <StageGrid stages={c.workflow.stages} />
           </Container>
         </Section>
 
-        {/* Traceability — the chain, then the confidence labels. */}
+        {/* Gap analysis and the evidence trail. */}
         <Section surface="ember">
           <Container>
             <SectionHeader heading={c.trace.heading} body={c.trace.body} />
@@ -137,9 +141,7 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
                       <dt className="font-mono text-label uppercase tracking-[0.085em] text-accent">
                         {label.code}
                       </dt>
-                      <dd className="mt-2 text-small text-fg-muted">
-                        {label.note}
-                      </dd>
+                      <dd className="mt-2 text-small text-fg-muted">{label.note}</dd>
                     </div>
                   ))}
                 </dl>
@@ -148,23 +150,26 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
           </Container>
         </Section>
 
-        {/* Before / after, and who decides. */}
+        {/* Deliverables — the remediation plan and the report, shown. */}
         <Section surface="ink">
           <Container>
-            <SectionHeader heading={c.comparison.heading} />
-            <div className="mt-12 grid grid-cols-[minmax(0,1fr)] gap-10 sm:grid-cols-2 lg:gap-16">
-              <FitList
-                title={c.comparison.before.title}
-                items={c.comparison.before.items}
-                tone="no"
-              />
-              <FitList
-                title={c.comparison.after.title}
-                items={c.comparison.after.items}
-                tone="yes"
-              />
+            <SectionHeader heading={c.deliverables.heading} />
+            <div className="mt-12 grid grid-cols-[minmax(0,1fr)] items-start gap-10 lg:grid-cols-[minmax(0,1.25fr)_minmax(0,1fr)] lg:gap-14">
+              <RemediationTable content={c.deliverables.remediation} />
+              <ReportPreview content={c.deliverables.report} />
             </div>
-            <Callout heading={c.comparison.review.heading} className="mt-14">
+          </Container>
+        </Section>
+
+        {/* Before / after, and who decides. */}
+        <Section surface="ember">
+          <Container>
+            <SectionHeader heading={c.comparison.heading} />
+            <div className="mt-12">
+              <FlowCompare comparison={c.comparison} />
+            </div>
+            <Note className="mt-6">{c.comparison.note}</Note>
+            <Callout heading={c.comparison.review.heading} className="mt-12">
               {c.comparison.review.body.map((p) => (
                 <Text key={p}>{p}</Text>
               ))}
@@ -173,9 +178,9 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
         </Section>
 
         {/* Use cases — banks, fintechs, insurers. */}
-        <Section surface="ember">
+        <Section surface="ink">
           <Container>
-            <SectionHeader heading={c.useCases.heading} body={c.useCases.body} />
+            <SectionHeader heading={c.useCases.heading} />
             <div className="mt-12 grid grid-cols-[minmax(0,1fr)] gap-10 sm:grid-cols-2 lg:grid-cols-3 lg:gap-8">
               {c.useCases.groups.map((group) => (
                 <div key={group.title}>
@@ -197,25 +202,19 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
           </Container>
         </Section>
 
-        {/* Deployment posture, and the honest Indonesia status. */}
-        <Section surface="ink">
+        {/* The Indonesian deployment — corpus, ingestion, environment. */}
+        <Section surface="ink" className="border-t border-border">
           <Container>
-            <SectionHeader heading={c.trust.heading} />
+            <SectionHeader heading={c.indonesia.heading} />
             <dl className="mt-12 grid grid-cols-[minmax(0,1fr)] gap-px overflow-hidden rounded-card border border-border bg-border sm:grid-cols-2">
-              {c.trust.items.map((item) => (
+              {c.indonesia.items.map((item) => (
                 <div key={item.title} className="bg-surface-raised p-6">
                   <dt className="text-body font-medium text-fg">{item.title}</dt>
                   <dd className="mt-2 text-small text-fg-muted">{item.note}</dd>
                 </div>
               ))}
             </dl>
-
-            <div className="mt-16 max-w-prose">
-              <Heading level={3} size="heading-1">
-                {c.trust.status.heading}
-              </Heading>
-              <Prose paragraphs={c.trust.status.body} size="body" className="mt-4" />
-            </div>
+            <Note className="mt-8">{c.indonesia.note}</Note>
           </Container>
         </Section>
 

--- a/src/components/indonesia/visuals.tsx
+++ b/src/components/indonesia/visuals.tsx
@@ -1,16 +1,222 @@
-import { Check } from "lucide-react";
+import type { ComponentType } from "react";
+import {
+  ClipboardCheck,
+  FileCheck2,
+  FileOutput,
+  FileText,
+  FolderOpen,
+  History,
+  Layers,
+  Library,
+  Link2,
+  ListChecks,
+  ScanSearch,
+  SearchX,
+  TriangleAlert,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { ChainNodeContent } from "@/content/indonesia/types";
+import type {
+  ChainNodeContent,
+  IndoContent,
+  IndoIcon,
+} from "@/content/indonesia/types";
 import { PulseDot } from "@/components/visuals";
 
 /* ==========================================================================
-   TraceChain — the traceability argument, drawn
+   Compliance-specific visual vocabulary
    --------------------------------------------------------------------------
-   Requirement → evidence → source → finding → reviewer, joined by one
-   continuous rail. The rail is the point: a visitor should see that nothing
-   on it stands alone. Same visual grammar as the rest of the site — thin
-   rules, small nodes, one accent, no boxes inside boxes. All content comes
-   from the locale dictionary, so the illustration localises with the page.
+   Everything here draws a compliance concept — an assessment overview, a
+   gap-analysis chain, a remediation extract, a report structure — rather
+   than a generic interface rectangle. Same grammar as the rest of the site:
+   thin rules, small nodes, one accent, tokens only. Content always comes
+   from the locale dictionaries, so every illustration localises with the
+   page, and anything with figures carries the dictionary's "Illustrative"
+   tag.
+   ========================================================================== */
+
+/** Dictionary icon keys → lucide marks, kept in one place so the content
+ *  files stay plain data. */
+const ICONS: Record<IndoIcon, ComponentType<{ className?: string }>> = {
+  corpus: Library,
+  policy: FileText,
+  evidence: FolderOpen,
+  history: History,
+  assessment: ClipboardCheck,
+  map: Link2,
+  gap: SearchX,
+  severity: TriangleAlert,
+  remediation: ListChecks,
+  report: FileOutput,
+  ground: Layers,
+  assess: ScanSearch,
+  review: FileCheck2,
+};
+
+const TONE_FILL = {
+  positive: "bg-success",
+  neutral: "bg-fg-subtle",
+  attention: "bg-accent",
+} as const;
+
+/* ==========================================================================
+   AssessmentOverview — the hero panel
+   --------------------------------------------------------------------------
+   What an assessment looks like at a glance: how many requirements, how they
+   split across compliant / partial / gap, the open findings, and the review
+   state. The figures are illustrative and the panel says so in its corner.
+   ========================================================================== */
+
+export function AssessmentOverview({
+  panel,
+}: {
+  panel: IndoContent["hero"]["panel"];
+}) {
+  return (
+    <div className="p-6">
+      <div className="flex items-baseline justify-between gap-4">
+        <p className="text-small text-fg-subtle">{panel.caption}</p>
+        <p className="shrink-0 font-mono text-label uppercase tracking-[0.085em] text-fg-subtle">
+          {panel.tag}
+        </p>
+      </div>
+
+      <p className="mt-4 flex items-baseline gap-3">
+        <span className="font-mono text-display-2 text-fg">
+          {panel.headline.value}
+        </span>
+        <span className="text-small text-fg-muted">{panel.headline.label}</span>
+      </p>
+
+      {/* Status distribution: one stacked bar, then its legend. */}
+      <div
+        aria-hidden
+        className="mt-4 flex h-2 gap-px overflow-hidden rounded-pill"
+      >
+        {panel.bar.map((seg) => (
+          <span
+            key={seg.label}
+            style={{ flexGrow: seg.count }}
+            className={cn("min-w-1", TONE_FILL[seg.tone])}
+          />
+        ))}
+      </div>
+      <ul className="mt-3 flex flex-wrap gap-x-5 gap-y-1.5">
+        {panel.bar.map((seg) => (
+          <li key={seg.label} className="flex items-center gap-2 text-small text-fg-muted">
+            <span aria-hidden className={cn("size-1.5 rounded-full", TONE_FILL[seg.tone])} />
+            {seg.label}
+            <span className="font-mono text-label text-fg-subtle">{seg.count}</span>
+          </li>
+        ))}
+      </ul>
+
+      <ul className="mt-5 space-y-3 border-t border-border pt-4">
+        {panel.rows.map((row, i) => (
+          <li key={row.label} className="flex items-center gap-2.5 text-small text-fg">
+            <PulseDot tone={row.tone} delay={i * 320} />
+            {row.label}
+          </li>
+        ))}
+      </ul>
+
+      <p className="mt-5 border-t border-border pt-4 text-fine text-fg-subtle">
+        {panel.footnote}
+      </p>
+    </div>
+  );
+}
+
+/* ==========================================================================
+   IconList — reads / produces
+   --------------------------------------------------------------------------
+   The executive question this answers is "what goes in, what do I get" — so
+   each item is an icon, a short label, and nothing else.
+   ========================================================================== */
+
+export function IconList({
+  items,
+  emphasis = false,
+  className,
+}: {
+  items: readonly { icon: IndoIcon; label: string; note?: string }[];
+  /** Outputs carry the accent; inputs stay quiet. */
+  emphasis?: boolean;
+  className?: string;
+}) {
+  return (
+    <ul className={cn("space-y-3.5", className)}>
+      {items.map((item) => {
+        const Icon = ICONS[item.icon];
+        return (
+          <li key={item.label} className="flex items-start gap-3.5">
+            <span
+              aria-hidden
+              className={cn(
+                "flex size-9 shrink-0 items-center justify-center rounded-control border",
+                emphasis
+                  ? "border-accent/40 text-accent"
+                  : "border-border-strong text-fg-subtle",
+              )}
+            >
+              <Icon className="size-4" />
+            </span>
+            <span className="min-w-0 pt-1.5">
+              <span className={cn("block text-body", emphasis ? "text-fg" : "text-fg-muted")}>
+                {item.label}
+              </span>
+              {item.note ? (
+                <span className="mt-0.5 block text-small text-fg-subtle">
+                  {item.note}
+                </span>
+              ) : null}
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+/* ==========================================================================
+   StageGrid — the four-stage workflow
+   --------------------------------------------------------------------------
+   Icon, name, one sentence. It must read correctly from those three alone.
+   ========================================================================== */
+
+export function StageGrid({
+  stages,
+}: {
+  stages: IndoContent["workflow"]["stages"];
+}) {
+  return (
+    <ol className="mt-12 grid grid-cols-[minmax(0,1fr)] gap-x-8 gap-y-10 sm:grid-cols-2 lg:grid-cols-4">
+      {stages.map((stage) => {
+        const Icon = ICONS[stage.icon];
+        return (
+          <li key={stage.n}>
+            <div className="flex items-center gap-3">
+              <span
+                aria-hidden
+                className="flex size-10 items-center justify-center rounded-control border border-border-strong text-accent"
+              >
+                <Icon className="size-5" />
+              </span>
+              <span className="font-mono text-label text-fg-subtle">{stage.n}</span>
+            </div>
+            <h3 className="mt-4 text-heading-1 text-fg">{stage.title}</h3>
+            <p className="mt-2 max-w-[36ch] text-body text-fg-muted">{stage.body}</p>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+/* ==========================================================================
+   TraceChain — gap analysis, one worked example
+   --------------------------------------------------------------------------
+   Requirement → evidence → gap → remediation → reviewer, joined by one
+   continuous rail. The rail is the point: nothing on it stands alone.
    ========================================================================== */
 
 export function TraceChain({
@@ -29,7 +235,6 @@ export function TraceChain({
           const last = i === nodes.length - 1;
           return (
             <li key={node.label} className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-4">
-              {/* The rail: a node, and the line carrying it to the next one. */}
               <div aria-hidden className="flex flex-col items-center">
                 <span className="flex h-6 items-center">
                   {node.accent ? (
@@ -62,49 +267,181 @@ export function TraceChain({
 }
 
 /* ==========================================================================
-   DeliverableList — the outputs, made unmistakable
+   RemediationTable — what a remediation plan actually looks like
    --------------------------------------------------------------------------
-   The executive question this answers is "what do I actually get?", so the
-   outputs carry check marks and a raised card while the inputs stay plain.
+   Finding | severity | action | target, three illustrative rows. A real
+   table from `sm` up; stacked cards below it, because four columns do not
+   survive 320px.
    ========================================================================== */
 
-export function DeliverableList({
-  items,
-  className,
+export function RemediationTable({
+  content,
 }: {
-  items: readonly string[];
-  className?: string;
+  content: IndoContent["deliverables"]["remediation"];
 }) {
+  const { columns, rows, caption } = content;
+
   return (
-    <ul className={cn("space-y-3.5", className)}>
-      {items.map((item) => (
-        <li key={item} className="flex gap-3">
-          <Check aria-hidden className="mt-1 size-4 shrink-0 text-accent" />
-          <span className="min-w-0 text-body text-fg">{item}</span>
-        </li>
-      ))}
-    </ul>
+    <figure>
+      <div className="overflow-hidden rounded-card border border-border bg-surface-raised">
+        {/* Table layout from `sm` up. */}
+        <div className="hidden sm:block">
+          <div className="grid grid-cols-[minmax(0,1.3fr)_auto_minmax(0,1.5fr)_auto] gap-x-5 border-b border-border px-5 py-3">
+            {[columns.finding, columns.severity, columns.action, columns.target].map(
+              (col) => (
+                <span
+                  key={col}
+                  className="font-mono text-label uppercase tracking-[0.085em] text-fg-subtle"
+                >
+                  {col}
+                </span>
+              ),
+            )}
+          </div>
+          {rows.map((row) => (
+            <div
+              key={row.finding}
+              className="grid grid-cols-[minmax(0,1.3fr)_auto_minmax(0,1.5fr)_auto] items-baseline gap-x-5 border-b border-border px-5 py-3.5 last:border-b-0"
+            >
+              <span className="text-small text-fg">{row.finding}</span>
+              <span className="flex items-center gap-2 text-small text-fg-muted">
+                <span aria-hidden className={cn("size-1.5 rounded-full", TONE_FILL[row.tone])} />
+                {row.severity}
+              </span>
+              <span className="text-small text-fg-muted">{row.action}</span>
+              <span className="font-mono text-label text-fg-subtle">{row.target}</span>
+            </div>
+          ))}
+        </div>
+
+        {/* Stacked below `sm`. */}
+        <ul className="sm:hidden">
+          {rows.map((row) => (
+            <li
+              key={row.finding}
+              className="space-y-1.5 border-b border-border p-5 last:border-b-0"
+            >
+              <p className="flex items-baseline justify-between gap-3">
+                <span className="text-small font-medium text-fg">{row.finding}</span>
+                <span className="flex shrink-0 items-center gap-2 text-small text-fg-muted">
+                  <span aria-hidden className={cn("size-1.5 rounded-full", TONE_FILL[row.tone])} />
+                  {row.severity}
+                </span>
+              </p>
+              <p className="text-small text-fg-muted">{row.action}</p>
+              <p className="font-mono text-label text-fg-subtle">{row.target}</p>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <figcaption className="mt-3 text-fine text-fg-subtle">{caption}</figcaption>
+    </figure>
   );
 }
 
-export function InputList({
-  items,
-  className,
+/* ==========================================================================
+   ReportPreview — the deliverable, as a document
+   --------------------------------------------------------------------------
+   A table of contents rather than a fake page: the sections a SecurePuls
+   report carries, in order, ending at the reviewer's sign-off.
+   ========================================================================== */
+
+export function ReportPreview({
+  content,
 }: {
-  items: readonly string[];
-  className?: string;
+  content: IndoContent["deliverables"]["report"];
 }) {
   return (
-    <ul className={cn("space-y-3.5", className)}>
-      {items.map((item) => (
-        <li key={item} className="flex gap-3">
-          <span
-            aria-hidden
-            className="mt-2.5 size-1.5 shrink-0 rounded-full bg-fg-subtle"
-          />
-          <span className="min-w-0 text-body text-fg-muted">{item}</span>
-        </li>
-      ))}
-    </ul>
+    <figure>
+      <div className="rounded-card border border-border bg-surface-raised p-6 sm:p-7">
+        <p className="border-b border-border-strong pb-4 text-heading-2 text-fg">
+          {content.title}
+        </p>
+        <ol className="mt-4 space-y-2.5">
+          {content.sections.map((section, i) => (
+            <li key={section} className="flex items-baseline gap-3">
+              <span className="font-mono text-label text-fg-subtle">
+                {String(i + 1).padStart(2, "0")}
+              </span>
+              <span className="text-body text-fg-muted">{section}</span>
+              <span aria-hidden className="mb-1 flex-1 self-end border-b border-dotted border-border" />
+            </li>
+          ))}
+        </ol>
+      </div>
+      <figcaption className="mt-3 text-fine text-fg-subtle">
+        {content.caption}
+      </figcaption>
+    </figure>
+  );
+}
+
+/* ==========================================================================
+   FlowCompare — the before / after, brutally simple
+   --------------------------------------------------------------------------
+   Two short vertical flows and their outcomes. The outcome lines carry the
+   story; everything else is five words per step.
+   ========================================================================== */
+
+function FlowColumn({
+  flow,
+  emphasis,
+}: {
+  flow: { title: string; steps: readonly string[]; outcome: string };
+  emphasis: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-card border p-6 sm:p-7",
+        emphasis ? "border-border-strong bg-surface-raised" : "border-border",
+      )}
+    >
+      <h3 className="text-small font-medium text-fg-subtle">{flow.title}</h3>
+      <ol className="mt-5">
+        {flow.steps.map((step, i) => {
+          const last = i === flow.steps.length - 1;
+          return (
+            <li key={step} className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3.5">
+              <div aria-hidden className="flex flex-col items-center">
+                <span className="flex h-5 items-center">
+                  <span
+                    className={cn(
+                      "size-1.5 rounded-full",
+                      emphasis ? "bg-accent" : "bg-border-strong",
+                    )}
+                  />
+                </span>
+                {!last ? <span className="w-px flex-1 bg-border" /> : null}
+              </div>
+              <p className={cn("text-body", last ? "pb-0" : "pb-3.5", emphasis ? "text-fg" : "text-fg-muted")}>
+                {step}
+              </p>
+            </li>
+          );
+        })}
+      </ol>
+      <p
+        className={cn(
+          "mt-5 border-t pt-4 text-heading-2",
+          emphasis ? "border-border-strong text-accent" : "border-border text-fg-subtle",
+        )}
+      >
+        {flow.outcome}
+      </p>
+    </div>
+  );
+}
+
+export function FlowCompare({
+  comparison,
+}: {
+  comparison: IndoContent["comparison"];
+}) {
+  return (
+    <div className="grid grid-cols-[minmax(0,1fr)] gap-6 sm:grid-cols-2 lg:gap-8">
+      <FlowColumn flow={comparison.before} emphasis={false} />
+      <FlowColumn flow={comparison.after} emphasis />
+    </div>
   );
 }

--- a/src/content/indonesia/en.ts
+++ b/src/content/indonesia/en.ts
@@ -4,138 +4,148 @@ import { ID_PATH } from "./locale";
 /**
  * SecurePuls Indonesia — English.
  *
- * Written to the executive standard: a time-constrained compliance, legal,
- * risk or audit decision-maker should know what the product is, what goes in,
- * what comes out, and where human review sits within two to three minutes.
+ * Written to the executive standard: a CCO, GC, CRO or audit executive gives
+ * this page two to three minutes. The headline carries the outcome and the
+ * time compression; the first sections carry the concrete inputs and
+ * deliverables; everything else is depth.
  *
- * Claim discipline (audited against the product repositories):
- *  - Every capability stated is implemented in the SecurePuls product today.
- *  - No named Indonesian regulation, regulator, framework or law. The
- *    regulatory corpus is configured per engagement; this page names no
- *    framework until support for it is verified.
- *  - No certifications, endorsements, percentages, time savings, customer
- *    names or counts. The worked example in the traceability section is
- *    labelled illustrative.
+ * Claim discipline:
+ *  - The ~30-minute figure is founder/practitioner-supplied evidence from the
+ *    working SecurePuls workflow, reviewed by a senior regulatory lawyer. It
+ *    is always qualified ("about", "for a configured assessment") and never
+ *    an SLA. The qualification line appears with the claim, once per claim
+ *    cluster, and stays short.
+ *  - OJK, Bank Indonesia and insurance-sector requirements are named only as
+ *    target corpus categories configured per engagement — never as approved,
+ *    certified or completely covered.
+ *  - Illustrative figures appear only inside mockups tagged "Illustrative".
+ *  - "Review-ready", never "audit-ready" — SecurePuls does not confer audit
+ *    assurance.
  */
 export const EN: IndoContent = {
   locale: "en",
   meta: {
-    title: "SecurePuls Indonesia — compliance assessment with the evidence attached",
+    title: "SecurePuls Indonesia — AI-assisted compliance assessment",
     description:
-      "SecurePuls structures compliance assessment for Indonesian banks, fintechs and insurers: every requirement answered, findings graded and traced to their sources, and a report your own reviewers sign off.",
+      "Gap analysis, severity-ranked findings, a remediation plan and a review-ready draft report in about 30 minutes — grounded in the regulatory corpus configured for the engagement, traced to sources, and verified by your reviewers.",
     ogLocale: "en_GB",
   },
   chrome: {
     skip: "Skip to content",
     kaibreHome: "Kaibre — company site",
     marketLabel: "Indonesia",
-    toggle: {
-      navLabel: "Language",
-      en: "English",
-      id: "Bahasa Indonesia",
-    },
+    toggle: { navLabel: "Language", en: "English", id: "Bahasa Indonesia" },
     cta: { label: "Discuss an assessment", href: "#contact" },
   },
   hero: {
-    audience: "For banks, fintechs and insurers in Indonesia",
-    headline: "Compliance assessment, with the evidence attached.",
-    body: "SecurePuls turns a set of requirements and your organisation's evidence into a structured, review-ready assessment: every requirement answered, findings graded by severity and traced to their sources, and a report your own reviewers sign off.",
+    kicker: "AI-assisted compliance assessment, for banks, fintechs and insurers in Indonesia",
+    headline: "Compliance assessment drafts in about 30 minutes, not weeks.",
+    body: "SecurePuls reads the regulatory corpus configured for the engagement alongside your policies and evidence, maps each requirement to its evidence, drafts the gap analysis — severity-ranked findings, remediation plan — and produces a review-ready draft report. Your reviewers verify and sign off.",
+    timingNote:
+      "Timing varies with assessment scope, evidence volume, and configuration.",
     cta: { label: "Discuss an assessment", href: "#contact" },
     secondary: { label: "See the workflow", href: "#workflow" },
     panel: {
-      alt: "Draft assessment findings for an internal control review, each row carrying its evidence status, awaiting reviewer sign-off.",
-      caption: "Draft findings — internal control assessment",
-      rows: [
-        { label: "Access management", status: "Verified", tone: "positive" },
-        { label: "Business continuity", status: "Partial", tone: "neutral" },
-        { label: "Third-party oversight", status: "Gap", tone: "attention" },
+      alt: "Illustrative assessment overview: requirements assessed, their status distribution, open findings, and review state.",
+      tag: "Illustrative",
+      caption: "Regulatory assessment — banking",
+      headline: { value: "42", label: "requirements assessed" },
+      bar: [
+        { label: "Compliant", count: 31, tone: "positive" },
+        { label: "Partial", count: 6, tone: "neutral" },
+        { label: "Gap", count: 5, tone: "attention" },
       ],
-      footnote: "Findings stay drafts until a designated reviewer signs off.",
+      rows: [
+        { label: "5 findings — 1 critical, 2 high", tone: "attention" },
+        { label: "Evidence mapped to sources", tone: "positive" },
+        { label: "Awaiting reviewer verification", tone: "neutral" },
+      ],
+      footnote: "Findings stay drafts until the designated reviewer signs off.",
     },
     illustrationNote: "Interface illustration.",
   },
   inOut: {
     heading: "What goes in. What comes out.",
-    give: {
-      title: "You provide",
+    reads: {
+      title: "SecurePuls reads",
       items: [
-        "The requirement set the assessment runs against — regulatory provisions and internal policy, configured per engagement",
-        "Evidence against each requirement: your team's answers, notes and supporting attachments",
-        "A reviewer who owns the sign-off",
+        {
+          icon: "corpus",
+          label: "The applicable regulatory corpus",
+          note: "curated and configured for the engagement",
+        },
+        { icon: "policy", label: "Internal policies and procedures" },
+        { icon: "evidence", label: "Supporting evidence and documentation" },
+        { icon: "history", label: "Previous findings, where relevant" },
       ],
     },
-    get: {
+    produces: {
       title: "SecurePuls produces",
       items: [
-        "A structured assessment across consistent domains — each requirement phrased as a question your team can verify",
-        "Findings only where there is a genuine gap or uncertainty, graded Critical to Informational",
-        "Every regulatory reference labelled by the strength of the evidence behind it",
-        "Recommendations attached to each finding — immediate, short-term and long-term actions",
-        "A review-ready report — findings, risk matrix, roadmap — exported to PDF or Word",
+        { icon: "assessment", label: "Requirement-by-requirement control assessment" },
+        { icon: "map", label: "Evidence map with exact source references" },
+        { icon: "gap", label: "Gap analysis" },
+        { icon: "severity", label: "Findings ranked by severity" },
+        { icon: "remediation", label: "Remediation plan with recommendations" },
+        { icon: "report", label: "Review-ready draft report — PDF or Word" },
       ],
     },
   },
   workflow: {
-    heading: "From requirement set to signed report.",
-    steps: [
+    heading: "Four stages. One evidence trail.",
+    stages: [
       {
         n: "01",
-        title: "Configure the engagement",
-        body: "The applicable requirement set is configured for the engagement, drawn from a maintained knowledge base rather than generated freely.",
+        icon: "ground",
+        title: "Ground",
+        body: "The regulatory corpus, your policies, and your evidence — in one place.",
       },
       {
         n: "02",
-        title: "Generate the assessment",
-        body: "SecurePuls structures the requirements into consistent domains, each one phrased as a question your team can verify.",
+        icon: "assess",
+        title: "Assess",
+        body: "AI maps requirements to evidence and drafts the gap analysis.",
       },
       {
         n: "03",
-        title: "Record the evidence",
-        body: "Status, notes and supporting attachments are captured against each requirement as your team works through it.",
+        icon: "remediation",
+        title: "Remediate",
+        body: "Findings ranked by severity, each with a remediation action.",
       },
       {
         n: "04",
-        title: "Draft the findings",
-        body: "Findings are raised only where there is a genuine gap or uncertainty — graded by severity, with recommendations attached.",
-      },
-      {
-        n: "05",
-        title: "Review and sign off",
-        body: "Your reviewer accepts or corrects every finding. Nothing becomes final without sign-off from a designated reviewer.",
-      },
-      {
-        n: "06",
-        title: "Export the report",
-        body: "A structured report carrying the findings, risk matrix and roadmap, exported to PDF or Word.",
+        icon: "review",
+        title: "Review & report",
+        body: "Your reviewer verifies the conclusions. SecurePuls produces the report.",
       },
     ],
   },
   trace: {
     heading: "No finding without a source.",
-    body: "A conclusion you cannot trace is a conclusion you cannot defend. SecurePuls keeps the chain intact — from the requirement, to the evidence recorded against it, to the source behind it, to the reviewer who signed it off.",
+    body: "Every finding stays linked to its evidence, the source behind it, and the reviewer who verified it.",
     chain: [
       {
-        label: "Requirement",
+        label: "Regulatory requirement",
         text: "Access rights to customer data are reviewed on a defined schedule.",
       },
       {
-        label: "Evidence recorded",
-        text: "Status: gap — no review record for the two most recent cycles.",
+        label: "Evidence found",
+        text: "Policy requires quarterly reviews — no review records for the two most recent quarters.",
+        meta: "Source: access-management policy, review section",
       },
       {
-        label: "Source",
-        text: "Internal access-management policy, review section.",
-        meta: "Evidence label: VERIFIED",
-      },
-      {
-        label: "Draft finding",
+        label: "Gap",
         text: "Periodic access reviews not evidenced.",
         meta: "Severity: High",
         accent: true,
       },
       {
-        label: "Reviewer decision",
-        text: "Confirmed and signed off by the designated reviewer.",
+        label: "Remediation",
+        text: "Reinstate the review cycle and retain sign-off records.",
+      },
+      {
+        label: "Reviewer verification",
+        text: "Confirmed by the designated reviewer.",
       },
     ],
     caption: "Illustrative example — not drawn from any specific regulation.",
@@ -159,97 +169,140 @@ export const EN: IndoContent = {
       },
     ],
   },
-  comparison: {
-    heading: "The same assessment, without the fragmentation.",
-    before: {
-      title: "The manual process",
-      items: [
-        "Requirements tracked in spreadsheets",
-        "Evidence chased over email and shared folders",
-        "Findings copied between documents",
-        "Sources re-checked by hand at review",
-        "The report assembled last, under deadline",
+  deliverables: {
+    heading: "What you receive.",
+    remediation: {
+      caption: "Remediation plan — extract. Illustrative.",
+      columns: {
+        finding: "Finding",
+        severity: "Severity",
+        action: "Remediation",
+        target: "Target",
+      },
+      rows: [
+        {
+          finding: "Access reviews not evidenced",
+          severity: "High",
+          tone: "attention",
+          action: "Reinstate the quarterly review cycle",
+          target: "30 days",
+        },
+        {
+          finding: "Incident escalation untested",
+          severity: "Medium",
+          tone: "neutral",
+          action: "Run and document an escalation exercise",
+          target: "60 days",
+        },
+        {
+          finding: "Retention schedule out of date",
+          severity: "Low",
+          tone: "positive",
+          action: "Align the schedule with current policy",
+          target: "90 days",
+        },
       ],
+    },
+    report: {
+      caption: "Draft report — structure",
+      title: "Compliance assessment report",
+      sections: [
+        "Executive summary",
+        "Gap analysis",
+        "Findings and severity",
+        "Remediation plan",
+        "Source references",
+        "Reviewer sign-off",
+      ],
+    },
+  },
+  comparison: {
+    heading: "What changes.",
+    before: {
+      title: "Manual assessment",
+      steps: [
+        "Reading the regulations",
+        "Spreadsheets and trackers",
+        "Chasing evidence",
+        "Manual gap analysis",
+        "Writing the report",
+      ],
+      outcome: "Days to weeks",
     },
     after: {
       title: "With SecurePuls",
-      items: [
-        "One structure holds requirements, evidence and findings",
-        "Evidence is recorded where the requirement lives",
-        "Sources stay attached as findings move",
-        "Review happens inside the same workflow",
-        "The report is generated from what was already reviewed",
+      steps: [
+        "Corpus, policies and evidence in one place",
+        "AI-assisted assessment",
+        "Gap analysis and remediation plan",
+        "Reviewer verification",
+        "Review-ready draft report",
       ],
+      outcome: "About 30 minutes to a first draft",
     },
+    note: "Timing varies with assessment scope, evidence volume, and configuration.",
     review: {
       heading: "SecurePuls drafts. Your team decides.",
       body: [
-        "SecurePuls is professional tooling for compliance work — not a legal opinion, not an audit, and not a certification. AI-assisted analysis accelerates the reading, structuring and cross-referencing; judgment stays with your team.",
-        "Findings remain drafts until a qualified reviewer accepts them, and every report carries that sign-off.",
+        "AI accelerates the reading, mapping and cross-referencing — and every conclusion stays visible, challengeable, and traceable to its evidence.",
+        "SecurePuls is professional tooling — not a legal opinion, an audit, or a certification. Findings remain drafts until a qualified reviewer verifies them, and every report carries that sign-off.",
       ],
     },
   },
   useCases: {
     heading: "Built for regulated work.",
-    body: "The same assessment structure carries the recurring, evidence-heavy work each institution already does.",
     groups: [
       {
         title: "Banks",
         items: [
           "Recurring regulatory and internal control assessments",
-          "Policy-to-requirement mapping ahead of a regulatory review",
-          "Evidence collection that stays attached to the requirement",
+          "Policy-to-requirement mapping with control gap analysis",
+          "Evidence-backed findings and remediation tracking",
         ],
       },
       {
         title: "Fintechs",
         items: [
-          "Preparing evidence for a regulatory review",
-          "Keeping compliance documentation current through rapid product change",
-          "Repeating control assessments without rebuilding them",
+          "Regulatory readiness ahead of a licensing step or review",
+          "Evidence kept current through rapid product change",
+          "Policy and control assessment with gap remediation",
         ],
       },
       {
         title: "Insurers",
         items: [
-          "Tracking regulatory obligations and internal policy in one structure",
-          "Recurring governance and compliance reporting",
-          "Assessment evidence reviewed before it reaches the report",
+          "Regulatory obligation assessment",
+          "Governance and policy review",
+          "Recurring compliance reporting with findings and remediation",
         ],
       },
     ],
   },
-  trust: {
-    heading: "Ready for your environment.",
+  indonesia: {
+    heading: "Built around the regulations that apply to your institution.",
     items: [
       {
-        title: "Self-contained deployment",
-        note: "SecurePuls runs as its own deployment with its own database, and can be operated inside your environment.",
+        title: "Curated Indonesian regulatory knowledge base",
+        note: "Indonesian deployments are configured with the regulatory corpus for the engagement — OJK, Bank Indonesia and insurance-sector requirements as applicable — with source references.",
       },
       {
-        title: "Controlled access",
-        note: "Accounts are created by your administrator. There is no public sign-up.",
+        title: "Document ingestion for the engagement",
+        note: "SecurePuls can be configured to ingest the applicable corpus alongside your policies, procedures and evidence.",
+      },
+      {
+        title: "Self-contained deployment",
+        note: "Its own database, administrator-created accounts, no public sign-up — and it can be operated inside your environment.",
       },
       {
         title: "Configurable model endpoint",
-        note: "The analysis model is configured per deployment and can point at an approved, OpenAI-compatible endpoint.",
-      },
-      {
-        title: "Traceable assessment content",
-        note: "Every finding stays linked to the evidence and answers it came from.",
+        note: "Analysis can run against an approved, OpenAI-compatible endpoint.",
       },
     ],
-    status: {
-      heading: "Where SecurePuls stands in Indonesia",
-      body: [
-        "SecurePuls is built and operated by Kaibre, and is in active development and demonstration with regulated organisations. The requirement sets an assessment runs against are configured per engagement — and this page will name Indonesian frameworks only once support for them is verified.",
-        "If your team assesses against regulatory or internal requirements in Indonesia, we would like to walk you through the current build.",
-      ],
-    },
+    note: "SecurePuls does not claim regulator approval. Corpus coverage is scoped and verified per engagement.",
   },
   contact: {
     heading: "Discuss an assessment.",
-    body: "Tell us about the assessment work your team does — which requirements, how often, and who reviews it. It reaches the people building SecurePuls.",
+    body: "Tell us which requirements your team assesses against and who reviews the result. It reaches the people building SecurePuls.",
     form: {
       name: { label: "Name", error: "Please add your name." },
       email: {

--- a/src/content/indonesia/id.ts
+++ b/src/content/indonesia/id.ts
@@ -4,50 +4,59 @@ import { EN_PATH } from "./locale";
 /**
  * SecurePuls Indonesia — Bahasa Indonesia.
  *
- * Ditulis langsung dalam ragam formal untuk audiens kepatuhan, hukum, risiko
- * dan audit di sektor jasa keuangan — bukan terjemahan kata per kata. Istilah
- * teknis yang lazim dipakai dalam bahasa Inggris di lingkungan perusahaan
- * Indonesia dipertahankan (gap, deployment, endpoint, spreadsheet, email,
- * PDF, Word, fintech, AI), begitu pula label bukti pada antarmuka produk
- * (VERIFIED / PARTIAL / INFERRED / GAP).
+ * Ditulis langsung dalam ragam formal untuk eksekutif kepatuhan, hukum,
+ * risiko dan audit — bukan terjemahan kata per kata, dan tidak lebih panjang
+ * dari versi Inggrisnya. Istilah yang lazim dipakai dalam bahasa Inggris di
+ * praktik kepatuhan Indonesia dipertahankan (gap analysis, gap, deployment,
+ * endpoint, spreadsheet, fintech, AI, PDF, Word, label bukti VERIFIED /
+ * PARTIAL / INFERRED / GAP); selebihnya memakai istilah baku: kepatuhan,
+ * ketentuan, temuan, keparahan, remediasi, verifikasi penelaah, jejak bukti,
+ * korpus regulasi.
  *
- * Disiplin klaim mengikuti `en.ts`: tidak ada regulasi, regulator, kerangka
- * atau undang-undang Indonesia yang disebut namanya; tidak ada sertifikasi,
- * persentase, atau nama pelanggan. Contoh pada bagian ketertelusuran diberi
- * label ilustratif.
+ * Disiplin klaim mengikuti `en.ts`: angka ±30 menit selalu dengan kualifikasi
+ * ("sekitar", "untuk asesmen yang telah dikonfigurasi"); OJK, Bank Indonesia,
+ * dan sektor asuransi disebut hanya sebagai kategori korpus yang
+ * dikonfigurasi per penugasan — tanpa klaim persetujuan atau cakupan penuh;
+ * angka di dalam mockup diberi label "Ilustratif".
  */
 export const ID: IndoContent = {
   locale: "id",
   meta: {
-    title: "SecurePuls Indonesia — asesmen kepatuhan lengkap dengan buktinya",
+    title: "SecurePuls Indonesia — asesmen kepatuhan berbantuan AI",
     description:
-      "SecurePuls menyusun asesmen kepatuhan untuk bank, fintech, dan perusahaan asuransi di Indonesia: setiap ketentuan terjawab, setiap temuan tertelusur ke sumbernya, dan laporan disahkan oleh penelaah Anda sendiri.",
+      "Analisis kesenjangan, temuan berperingkat keparahan, rencana remediasi, dan draf laporan siap telaah dalam sekitar 30 menit — berlandaskan korpus regulasi yang dikonfigurasi untuk penugasan, tertelusur ke sumber, dan diverifikasi penelaah Anda.",
     ogLocale: "id_ID",
   },
   chrome: {
     skip: "Langsung ke konten",
     kaibreHome: "Kaibre — situs perusahaan",
     marketLabel: "Indonesia",
-    toggle: {
-      navLabel: "Bahasa",
-      en: "English",
-      id: "Bahasa Indonesia",
-    },
+    toggle: { navLabel: "Bahasa", en: "English", id: "Bahasa Indonesia" },
     cta: { label: "Diskusikan asesmen", href: "#contact" },
   },
   hero: {
-    audience: "Untuk bank, fintech, dan perusahaan asuransi di Indonesia",
-    headline: "Asesmen kepatuhan, lengkap dengan buktinya.",
-    body: "SecurePuls mengubah seperangkat ketentuan dan bukti dari organisasi Anda menjadi asesmen terstruktur yang siap ditelaah: setiap ketentuan terjawab, setiap temuan diberi peringkat keparahan dan tertelusur ke sumbernya, dan laporannya disahkan oleh penelaah Anda sendiri.",
+    kicker:
+      "Asesmen kepatuhan berbantuan AI — untuk bank, fintech, dan perusahaan asuransi di Indonesia",
+    headline: "Draf asesmen kepatuhan dalam sekitar 30 menit, bukan berminggu-minggu.",
+    body: "SecurePuls membaca korpus regulasi yang dikonfigurasi untuk penugasan beserta kebijakan dan bukti institusi Anda, memetakan setiap ketentuan ke buktinya, menyusun analisis kesenjangan — temuan berperingkat keparahan, rencana remediasi — dan menghasilkan draf laporan siap telaah. Penelaah Anda memverifikasi dan mengesahkannya.",
+    timingNote:
+      "Durasi bervariasi menurut cakupan asesmen, volume bukti, dan konfigurasi.",
     cta: { label: "Diskusikan asesmen Anda", href: "#contact" },
     secondary: { label: "Lihat alur kerjanya", href: "#workflow" },
     panel: {
-      alt: "Draf temuan asesmen untuk tinjauan pengendalian internal; setiap baris menampilkan status buktinya dan menunggu pengesahan penelaah.",
-      caption: "Draf temuan — asesmen pengendalian internal",
+      alt: "Ikhtisar asesmen ilustratif: jumlah ketentuan yang dinilai, distribusi statusnya, temuan terbuka, dan status telaah.",
+      tag: "Ilustratif",
+      caption: "Asesmen regulasi — perbankan",
+      headline: { value: "42", label: "ketentuan dinilai" },
+      bar: [
+        { label: "Patuh", count: 31, tone: "positive" },
+        { label: "Parsial", count: 6, tone: "neutral" },
+        { label: "Gap", count: 5, tone: "attention" },
+      ],
       rows: [
-        { label: "Manajemen akses", status: "Terverifikasi", tone: "positive" },
-        { label: "Kelangsungan usaha", status: "Parsial", tone: "neutral" },
-        { label: "Pengawasan pihak ketiga", status: "Gap", tone: "attention" },
+        { label: "5 temuan — 1 kritis, 2 tinggi", tone: "attention" },
+        { label: "Bukti terpetakan ke sumbernya", tone: "positive" },
+        { label: "Menunggu verifikasi penelaah", tone: "neutral" },
       ],
       footnote:
         "Temuan tetap berupa draf sampai disahkan oleh penelaah yang ditunjuk.",
@@ -56,86 +65,86 @@ export const ID: IndoContent = {
   },
   inOut: {
     heading: "Apa yang masuk. Apa yang keluar.",
-    give: {
-      title: "Yang Anda berikan",
+    reads: {
+      title: "Yang dibaca SecurePuls",
       items: [
-        "Seperangkat ketentuan yang menjadi acuan asesmen — ketentuan regulasi dan kebijakan internal, dikonfigurasi per penugasan",
-        "Bukti untuk setiap ketentuan: jawaban tim Anda, catatan, dan lampiran pendukung",
-        "Penelaah yang memegang kewenangan pengesahan",
+        {
+          icon: "corpus",
+          label: "Korpus regulasi yang berlaku",
+          note: "dikurasi dan dikonfigurasi untuk penugasan",
+        },
+        { icon: "policy", label: "Kebijakan dan prosedur internal" },
+        { icon: "evidence", label: "Bukti dan dokumentasi pendukung" },
+        { icon: "history", label: "Temuan terdahulu, bila relevan" },
       ],
     },
-    get: {
+    produces: {
       title: "Yang dihasilkan SecurePuls",
       items: [
-        "Asesmen terstruktur lintas domain yang konsisten — setiap ketentuan dirumuskan sebagai pertanyaan yang dapat diverifikasi tim Anda",
-        "Temuan hanya bila ada kesenjangan atau ketidakpastian yang nyata, dengan peringkat Kritis hingga Informasional",
-        "Setiap referensi regulasi diberi label sesuai kekuatan bukti di baliknya",
-        "Rekomendasi yang melekat pada setiap temuan — tindakan segera, jangka pendek, dan jangka panjang",
-        "Laporan siap telaah — temuan, matriks risiko, peta jalan — diekspor ke PDF atau Word",
+        { icon: "assessment", label: "Asesmen pengendalian ketentuan demi ketentuan" },
+        { icon: "map", label: "Peta bukti dengan rujukan sumber yang persis" },
+        { icon: "gap", label: "Analisis kesenjangan (gap analysis)" },
+        { icon: "severity", label: "Temuan berperingkat keparahan" },
+        { icon: "remediation", label: "Rencana remediasi beserta rekomendasi" },
+        { icon: "report", label: "Draf laporan siap telaah — PDF atau Word" },
       ],
     },
   },
   workflow: {
-    heading: "Dari seperangkat ketentuan menjadi laporan yang disahkan.",
-    steps: [
+    heading: "Empat tahap. Satu jejak bukti.",
+    stages: [
       {
         n: "01",
-        title: "Konfigurasikan penugasan",
-        body: "Seperangkat ketentuan yang berlaku dikonfigurasi untuk penugasan itu, diambil dari basis pengetahuan yang terpelihara — bukan dihasilkan secara bebas.",
+        icon: "ground",
+        title: "Landasan",
+        body: "Korpus regulasi, kebijakan, dan bukti Anda — dalam satu tempat.",
       },
       {
         n: "02",
-        title: "Susun asesmennya",
-        body: "SecurePuls menyusun ketentuan ke dalam domain-domain yang konsisten, masing-masing dirumuskan sebagai pertanyaan yang dapat diverifikasi tim Anda.",
+        icon: "assess",
+        title: "Asesmen",
+        body: "AI memetakan ketentuan ke bukti dan menyusun analisis kesenjangannya.",
       },
       {
         n: "03",
-        title: "Rekam buktinya",
-        body: "Status, catatan, dan lampiran pendukung direkam pada setiap ketentuan selagi tim Anda mengerjakannya.",
+        icon: "remediation",
+        title: "Remediasi",
+        body: "Temuan diperingkat keparahannya, masing-masing dengan tindakan remediasi.",
       },
       {
         n: "04",
-        title: "Susun draf temuan",
-        body: "Temuan hanya diangkat bila ada kesenjangan atau ketidakpastian yang nyata — diberi peringkat keparahan, dengan rekomendasi yang menyertainya.",
-      },
-      {
-        n: "05",
-        title: "Telaah dan sahkan",
-        body: "Penelaah Anda menerima atau mengoreksi setiap temuan. Tidak ada yang final tanpa pengesahan dari penelaah yang ditunjuk.",
-      },
-      {
-        n: "06",
-        title: "Ekspor laporannya",
-        body: "Laporan terstruktur memuat temuan, matriks risiko, dan peta jalan — diekspor ke PDF atau Word.",
+        icon: "review",
+        title: "Telaah & laporkan",
+        body: "Penelaah Anda memverifikasi kesimpulannya. SecurePuls menghasilkan laporannya.",
       },
     ],
   },
   trace: {
     heading: "Tidak ada temuan tanpa sumber.",
-    body: "Kesimpulan yang tidak dapat ditelusuri adalah kesimpulan yang tidak dapat dipertanggungjawabkan. SecurePuls menjaga rantainya tetap utuh — dari ketentuan, ke bukti yang direkam terhadapnya, ke sumber di baliknya, hingga penelaah yang mengesahkannya.",
+    body: "Setiap temuan tetap terhubung ke buktinya, sumber di baliknya, dan penelaah yang memverifikasinya.",
     chain: [
       {
-        label: "Ketentuan",
+        label: "Ketentuan regulasi",
         text: "Hak akses ke data nasabah ditinjau sesuai jadwal yang ditetapkan.",
       },
       {
-        label: "Bukti yang terekam",
-        text: "Status: gap — tidak ada catatan tinjauan untuk dua siklus terakhir.",
+        label: "Bukti yang ditemukan",
+        text: "Kebijakan mewajibkan tinjauan triwulanan — tidak ada catatan tinjauan untuk dua triwulan terakhir.",
+        meta: "Sumber: kebijakan manajemen akses, bagian peninjauan",
       },
       {
-        label: "Sumber",
-        text: "Kebijakan internal manajemen akses, bagian peninjauan.",
-        meta: "Label bukti: VERIFIED",
-      },
-      {
-        label: "Draf temuan",
+        label: "Kesenjangan (gap)",
         text: "Tinjauan akses berkala tidak terbukti dilaksanakan.",
         meta: "Keparahan: Tinggi",
         accent: true,
       },
       {
-        label: "Keputusan penelaah",
-        text: "Dikonfirmasi dan disahkan oleh penelaah yang ditunjuk.",
+        label: "Remediasi",
+        text: "Pulihkan siklus tinjauan dan simpan catatan pengesahannya.",
+      },
+      {
+        label: "Verifikasi penelaah",
+        text: "Dikonfirmasi oleh penelaah yang ditunjuk.",
       },
     ],
     caption: "Contoh ilustratif — tidak diambil dari regulasi tertentu.",
@@ -159,97 +168,140 @@ export const ID: IndoContent = {
       },
     ],
   },
-  comparison: {
-    heading: "Asesmen yang sama, tanpa proses yang terpecah.",
-    before: {
-      title: "Proses manual",
-      items: [
-        "Ketentuan dilacak di spreadsheet",
-        "Bukti dikejar lewat email dan folder bersama",
-        "Temuan disalin antar dokumen",
-        "Sumber diperiksa ulang secara manual saat telaah",
-        "Laporan dirakit paling akhir, di bawah tenggat",
+  deliverables: {
+    heading: "Yang Anda terima.",
+    remediation: {
+      caption: "Rencana remediasi — cuplikan. Ilustratif.",
+      columns: {
+        finding: "Temuan",
+        severity: "Keparahan",
+        action: "Remediasi",
+        target: "Target",
+      },
+      rows: [
+        {
+          finding: "Tinjauan akses tidak terbukti",
+          severity: "Tinggi",
+          tone: "attention",
+          action: "Pulihkan siklus tinjauan triwulanan",
+          target: "30 hari",
+        },
+        {
+          finding: "Eskalasi insiden belum teruji",
+          severity: "Sedang",
+          tone: "neutral",
+          action: "Laksanakan dan dokumentasikan latihan eskalasi",
+          target: "60 hari",
+        },
+        {
+          finding: "Jadwal retensi tidak mutakhir",
+          severity: "Rendah",
+          tone: "positive",
+          action: "Selaraskan dengan kebijakan berjalan",
+          target: "90 hari",
+        },
       ],
+    },
+    report: {
+      caption: "Draf laporan — struktur",
+      title: "Laporan asesmen kepatuhan",
+      sections: [
+        "Ringkasan eksekutif",
+        "Analisis kesenjangan",
+        "Temuan dan keparahan",
+        "Rencana remediasi",
+        "Rujukan sumber",
+        "Pengesahan penelaah",
+      ],
+    },
+  },
+  comparison: {
+    heading: "Apa yang berubah.",
+    before: {
+      title: "Asesmen manual",
+      steps: [
+        "Membaca regulasi satu per satu",
+        "Spreadsheet dan pelacak",
+        "Mengejar bukti",
+        "Analisis kesenjangan manual",
+        "Menulis laporan",
+      ],
+      outcome: "Berhari-hari hingga berminggu-minggu",
     },
     after: {
       title: "Dengan SecurePuls",
-      items: [
-        "Satu struktur memuat ketentuan, bukti, dan temuan",
-        "Bukti direkam tepat pada ketentuannya",
-        "Sumber tetap melekat saat temuan berpindah",
-        "Telaah berlangsung di dalam alur kerja yang sama",
-        "Laporan dihasilkan dari apa yang telah ditelaah",
+      steps: [
+        "Korpus, kebijakan, dan bukti dalam satu tempat",
+        "Asesmen berbantuan AI",
+        "Analisis kesenjangan dan rencana remediasi",
+        "Verifikasi penelaah",
+        "Draf laporan siap telaah",
       ],
+      outcome: "Sekitar 30 menit menuju draf pertama",
     },
+    note: "Durasi bervariasi menurut cakupan asesmen, volume bukti, dan konfigurasi.",
     review: {
       heading: "SecurePuls menyusun draf. Tim Anda yang memutuskan.",
       body: [
-        "SecurePuls adalah perangkat kerja profesional untuk pekerjaan kepatuhan — bukan opini hukum, bukan audit, dan bukan sertifikasi. Analisis berbantuan AI mempercepat pembacaan, penstrukturan, dan referensi silang; pertimbangan tetap berada di tangan tim Anda.",
-        "Temuan tetap berupa draf sampai diterima oleh penelaah yang kompeten, dan setiap laporan memuat pengesahan itu.",
+        "AI mempercepat pembacaan, pemetaan, dan referensi silang — dan setiap kesimpulan tetap terlihat, dapat digugat, dan tertelusur ke buktinya.",
+        "SecurePuls adalah perangkat kerja profesional — bukan opini hukum, audit, atau sertifikasi. Temuan tetap berupa draf sampai diverifikasi penelaah yang kompeten, dan setiap laporan memuat pengesahan itu.",
       ],
     },
   },
   useCases: {
     heading: "Dibangun untuk pekerjaan yang teregulasi.",
-    body: "Struktur asesmen yang sama menampung pekerjaan berulang dan sarat bukti yang sudah dijalankan setiap lembaga.",
     groups: [
       {
         title: "Bank",
         items: [
           "Asesmen berkala atas ketentuan regulasi dan pengendalian internal",
-          "Pemetaan kebijakan terhadap ketentuan menjelang tinjauan regulator",
-          "Pengumpulan bukti yang tetap melekat pada ketentuannya",
+          "Pemetaan kebijakan ke ketentuan dengan analisis kesenjangan pengendalian",
+          "Temuan berbasis bukti dan pemantauan remediasi",
         ],
       },
       {
         title: "Fintech",
         items: [
-          "Menyiapkan bukti untuk tinjauan regulator",
-          "Menjaga dokumentasi kepatuhan tetap mutakhir di tengah perubahan produk yang cepat",
-          "Mengulang asesmen pengendalian tanpa menyusunnya dari awal",
+          "Kesiapan regulasi menjelang perizinan atau tinjauan",
+          "Bukti tetap mutakhir di tengah perubahan produk yang cepat",
+          "Asesmen kebijakan dan pengendalian dengan remediasi kesenjangan",
         ],
       },
       {
         title: "Perusahaan asuransi",
         items: [
-          "Melacak kewajiban regulasi dan kebijakan internal dalam satu struktur",
-          "Pelaporan tata kelola dan kepatuhan secara berkala",
-          "Bukti asesmen ditelaah sebelum masuk ke laporan",
+          "Asesmen kewajiban regulasi",
+          "Tinjauan tata kelola dan kebijakan",
+          "Pelaporan kepatuhan berkala dengan temuan dan remediasinya",
         ],
       },
     ],
   },
-  trust: {
-    heading: "Siap untuk lingkungan Anda.",
+  indonesia: {
+    heading: "Dibangun di sekitar regulasi yang berlaku bagi institusi Anda.",
     items: [
       {
-        title: "Deployment mandiri",
-        note: "SecurePuls berjalan sebagai deployment tersendiri dengan basis data sendiri, dan dapat dioperasikan di dalam lingkungan Anda.",
+        title: "Basis pengetahuan regulasi Indonesia yang terkurasi",
+        note: "Deployment di Indonesia dikonfigurasi dengan korpus regulasi untuk penugasan — ketentuan OJK, Bank Indonesia, dan sektor asuransi sesuai relevansinya — lengkap dengan rujukan sumber.",
       },
       {
-        title: "Akses terkendali",
-        note: "Akun dibuat oleh administrator Anda. Tidak ada pendaftaran publik.",
+        title: "Pemuatan dokumen untuk penugasan",
+        note: "SecurePuls dapat dikonfigurasi untuk memuat korpus regulasi yang berlaku beserta kebijakan, prosedur, dan bukti institusi Anda.",
+      },
+      {
+        title: "Deployment mandiri",
+        note: "Basis data sendiri, akun dibuat administrator, tanpa pendaftaran publik — dan dapat dioperasikan di dalam lingkungan Anda.",
       },
       {
         title: "Endpoint model dapat dikonfigurasi",
-        note: "Model analisis dikonfigurasi per deployment dan dapat diarahkan ke endpoint kompatibel OpenAI yang Anda setujui.",
-      },
-      {
-        title: "Konten asesmen tertelusur",
-        note: "Setiap temuan tetap terhubung ke bukti dan jawaban asalnya.",
+        note: "Analisis dapat dijalankan pada endpoint kompatibel OpenAI yang Anda setujui.",
       },
     ],
-    status: {
-      heading: "Posisi SecurePuls di Indonesia",
-      body: [
-        "SecurePuls dibangun dan dioperasikan oleh Kaibre, serta sedang dalam pengembangan dan demonstrasi aktif bersama organisasi-organisasi yang teregulasi. Seperangkat ketentuan yang menjadi acuan asesmen dikonfigurasi per penugasan — dan halaman ini baru akan menyebut kerangka regulasi Indonesia setelah dukungannya terverifikasi.",
-        "Jika tim Anda melakukan asesmen terhadap ketentuan regulasi atau ketentuan internal di Indonesia, kami ingin memperlihatkan versi terkini produk ini kepada Anda.",
-      ],
-    },
+    note: "SecurePuls tidak mengklaim persetujuan regulator. Cakupan korpus ditetapkan dan diverifikasi per penugasan.",
   },
   contact: {
     heading: "Diskusikan asesmen Anda.",
-    body: "Ceritakan pekerjaan asesmen tim Anda — ketentuan apa yang menjadi acuan, seberapa sering dilakukan, dan siapa yang menelaahnya. Pesan Anda sampai langsung ke tim yang membangun SecurePuls.",
+    body: "Sampaikan ketentuan apa yang menjadi acuan asesmen tim Anda dan siapa yang menelaah hasilnya. Pesan Anda sampai langsung ke tim yang membangun SecurePuls.",
     form: {
       name: { label: "Nama", error: "Mohon isi nama Anda." },
       email: {

--- a/src/content/indonesia/types.ts
+++ b/src/content/indonesia/types.ts
@@ -5,19 +5,30 @@
  * synchronisation guarantee: a section, item or label added to one locale
  * fails the build until the other carries it too. Components never contain
  * copy and never branch on locale — they render whichever dictionary the
- * route hands them.
+ * route hands them. Icons are referenced by key so the dictionaries stay
+ * plain data; the key → icon map lives in the visuals module.
  */
 
 export type IndoLocale = "en" | "id";
 
-export interface StatusRowContent {
-  label: string;
-  status: string;
-  tone: "positive" | "attention" | "neutral";
-}
+/** Icon vocabulary for the reads/produces and workflow visuals. */
+export type IndoIcon =
+  | "corpus"
+  | "policy"
+  | "evidence"
+  | "history"
+  | "assessment"
+  | "map"
+  | "gap"
+  | "severity"
+  | "remediation"
+  | "report"
+  | "ground"
+  | "assess"
+  | "review";
 
 export interface ChainNodeContent {
-  /** What kind of thing this node is — "Requirement", "Evidence", … */
+  /** What kind of thing this node is — "Regulatory requirement", "Gap", … */
   label: string;
   /** The illustrative content itself. */
   text: string;
@@ -36,40 +47,61 @@ export interface IndoContent {
   };
   chrome: {
     skip: string;
-    /** Accessible name for the wordmark link back to the Kaibre site. */
     kaibreHome: string;
-    /** Shown beside the product name in the header. */
     marketLabel: string;
-    toggle: {
-      navLabel: string;
-      en: string;
-      id: string;
-    };
+    toggle: { navLabel: string; en: string; id: string };
     cta: { label: string; href: string };
   };
   hero: {
-    audience: string;
+    /** The one line above the headline: AI-assisted + who it is for. */
+    kicker: string;
     headline: string;
     body: string;
+    /** The restrained qualification of the timing claim. */
+    timingNote: string;
     cta: { label: string; href: string };
     secondary: { label: string; href: string };
     panel: {
-      /** Accessible description of the illustration as a whole. */
       alt: string;
+      /** Corner tag marking the figures as illustrative. */
+      tag: string;
       caption: string;
-      rows: readonly StatusRowContent[];
+      /** The headline figure — "42" + "requirements assessed". */
+      headline: { value: string; label: string };
+      /** Stacked distribution bar with its legend. */
+      bar: readonly {
+        label: string;
+        count: number;
+        tone: "positive" | "neutral" | "attention";
+      }[];
+      /** Compact status rows under the bar. */
+      rows: readonly {
+        label: string;
+        tone: "positive" | "attention" | "neutral";
+      }[];
       footnote: string;
     };
     illustrationNote: string;
   };
   inOut: {
     heading: string;
-    give: { title: string; items: readonly string[] };
-    get: { title: string; items: readonly string[] };
+    reads: {
+      title: string;
+      items: readonly { icon: IndoIcon; label: string; note?: string }[];
+    };
+    produces: {
+      title: string;
+      items: readonly { icon: IndoIcon; label: string }[];
+    };
   };
   workflow: {
     heading: string;
-    steps: readonly { n: string; title: string; body: string }[];
+    stages: readonly {
+      n: string;
+      icon: IndoIcon;
+      title: string;
+      body: string;
+    }[];
   };
   trace: {
     heading: string;
@@ -79,21 +111,41 @@ export interface IndoContent {
     labelsHeading: string;
     labels: readonly { code: string; note: string }[];
   };
+  deliverables: {
+    heading: string;
+    remediation: {
+      caption: string;
+      columns: { finding: string; severity: string; action: string; target: string };
+      rows: readonly {
+        finding: string;
+        severity: string;
+        tone: "attention" | "neutral" | "positive";
+        action: string;
+        target: string;
+      }[];
+    };
+    report: {
+      caption: string;
+      title: string;
+      sections: readonly string[];
+    };
+  };
   comparison: {
     heading: string;
-    before: { title: string; items: readonly string[] };
-    after: { title: string; items: readonly string[] };
+    before: { title: string; steps: readonly string[]; outcome: string };
+    after: { title: string; steps: readonly string[]; outcome: string };
+    /** The timing qualification, set once, beside the boldest claim. */
+    note: string;
     review: { heading: string; body: readonly string[] };
   };
   useCases: {
     heading: string;
-    body: string;
     groups: readonly { title: string; items: readonly string[] }[];
   };
-  trust: {
+  indonesia: {
     heading: string;
     items: readonly { title: string; note: string }[];
-    status: { heading: string; body: readonly string[] };
+    note: string;
   };
   contact: {
     heading: string;
@@ -103,7 +155,10 @@ export interface IndoContent {
       email: { label: string; errorMissing: string; errorInvalid: string };
       company: { label: string; error: string };
       role: { label: string };
-      orgType: { label: string; options: readonly { value: string; label: string }[] };
+      orgType: {
+        label: string;
+        options: readonly { value: string; label: string }[];
+      };
       need: { label: string; hint: string; placeholder: string; error: string };
       submit: string;
       sending: string;
@@ -114,7 +169,6 @@ export interface IndoContent {
   footer: {
     tagline: string;
     links: readonly { label: string; href: string }[];
-    /** The counterpart page, offered in its own language. */
     languageLink: { label: string; href: string };
   };
 }

--- a/tests/indonesia.spec.ts
+++ b/tests/indonesia.spec.ts
@@ -19,8 +19,9 @@ import { expect, test, type Page } from "@playwright/test";
 const EN_PATH = "/securepuls/indonesia";
 const ID_PATH = "/id/securepuls/indonesia";
 
-const EN_H1 = "Compliance assessment, with the evidence attached.";
-const ID_H1 = "Asesmen kepatuhan, lengkap dengan buktinya.";
+const EN_H1 = "Compliance assessment drafts in about 30 minutes, not weeks.";
+const ID_H1 =
+  "Draf asesmen kepatuhan dalam sekitar 30 menit, bukan berminggu-minggu.";
 
 /**
  * English terms approved for use inside Indonesian copy: the product and
@@ -43,11 +44,16 @@ const APPROVED_IN_ID = [
   "AI",
   "fintech",
   "deployment",
+  "Deployment",
   "endpoint",
+  "Endpoint",
   "spreadsheet",
+  "Spreadsheet",
   "email",
   "folder",
+  "gap analysis", // accepted alongside "analisis kesenjangan"
   "gap",
+  "Gap",
   "status",
   "Website", // hidden honeypot label
 ];
@@ -60,17 +66,27 @@ const ENGLISH_MARKERS =
 const INDONESIAN_MARKERS = /\b(dan|yang|untuk|dengan|kami|adalah|setiap)\b/gi;
 
 /**
- * Neither page may name an Indonesian regulator, framework or law — the
- * corpus is configured per engagement and nothing is claimed until verified —
- * and neither may carry a certification or guarantee in either language.
+ * OJK, Bank Indonesia and insurance-sector requirements may be named as
+ * target corpus categories configured per engagement — that framing is
+ * founder-approved. What must never appear, in either language: approval or
+ * endorsement by a regulator, certifications, guarantees, coverage claimed
+ * as complete, specific instruments (POJK/SEOJK numbers, UU PDP), other
+ * regulators the corpus does not target, percentages, or an unqualified
+ * timing promise.
  */
 const FORBIDDEN = [
-  /\b(OJK|PPATK|POJK|SEOJK|Kominfo)\b/,
-  /\bBank Indonesia\b/,
+  /\b(PPATK|POJK|SEOJK|Kominfo)\b/,
   /\b(UU\s?PDP|PDP Law)\b/i,
+  /\b(?:OJK|Bank Indonesia)[- ]approved\b/i,
+  /\b(?:approved|endorsed|licensed)\s+by\s+(?:OJK|Bank Indonesia|the regulator)\b/i,
+  /\bdisetujui\s+(?:oleh\s+)?(?:OJK|Bank Indonesia|regulator)\b/i,
+  /\b(?:complete|full)\s+coverage\b/i,
+  /\bcakupan\s+(?:penuh|lengkap|menyeluruh)\b/i,
   /\b(certified|accredited|regulator[- ]approved|guaranteed)\b/i,
   /\b(tersertifikasi|terakreditasi|kepatuhan otomatis)\b/i,
   /\bmenjamin\s+kepatuhan\b/i,
+  /\b(?:guaranteed|always|every assessment)\s+(?:in|within)\s+30\b/i,
+  /\bselalu\s+30\s+menit\b/i,
   /\b\d{1,3}\s?%/,
 ];
 
@@ -225,18 +241,68 @@ test.describe("no language leaks", () => {
 
 test.describe("regulatory guardrails", () => {
   for (const path of [EN_PATH, ID_PATH]) {
-    test(`${path} makes no forbidden claim and names no regulator`, async ({ page }) => {
+    test(`${path} makes no forbidden claim`, async ({ page }) => {
       await page.goto(path);
       const text = await visibleText(page);
       for (const re of FORBIDDEN) {
         const hit = re.exec(text);
         expect(hit, `"${hit?.[0]}" appears on ${path}`).toBeNull();
       }
-      // The illustrative example must be labelled as illustrative.
-      const label = path.startsWith("/id/") ? /Contoh ilustratif/ : /Illustrative example/;
+      // Illustrative material must be labelled as illustrative.
+      const label = path.startsWith("/id/") ? /ilustratif/i : /illustrative/i;
       expect(text).toMatch(label);
+      // The timing claim must never travel without its qualification.
+      const qualifier = path.startsWith("/id/")
+        ? /Durasi bervariasi/
+        : /Timing varies/;
+      expect(text).toMatch(qualifier);
     });
   }
+
+  /**
+   * The executive scan: a visitor reading only headings, bold terms and
+   * numbers must still meet the load-bearing concepts. These are the words
+   * that carry the page — if a rewrite drops one, this fails.
+   */
+  test("scan-level concepts are present in both locales", async ({ page }) => {
+    const expectations: [string, RegExp[]][] = [
+      [
+        EN_PATH,
+        [
+          /about 30 minutes/i,
+          /AI-assisted/i,
+          /gap analysis/i,
+          /remediation plan/i,
+          /severity/i,
+          /reviewer/i,
+          /regulatory corpus/i,
+          /OJK/,
+          /Bank Indonesia/,
+        ],
+      ],
+      [
+        ID_PATH,
+        [
+          /sekitar 30 menit/i,
+          /berbantuan AI/i,
+          /analisis kesenjangan/i,
+          /rencana remediasi/i,
+          /keparahan/i,
+          /penelaah/i,
+          /korpus regulasi/i,
+          /OJK/,
+          /Bank Indonesia/,
+        ],
+      ],
+    ];
+    for (const [path, terms] of expectations) {
+      await page.goto(path);
+      const text = await visibleText(page);
+      for (const term of terms) {
+        expect(text, `${path} is missing ${term}`).toMatch(term);
+      }
+    }
+  });
 });
 
 /* --------------------------------------------------------------------------


### PR DESCRIPTION
Founder-directed refinement pass: specific, simpler, faster to understand.

- Hero states the outcome outright — "Compliance assessment drafts in about 30 minutes, not weeks" — under an AI-assisted kicker; timing claim always qualified, never an SLA
- Indonesian offering framed commercially: curated regulatory corpus configured per engagement (OJK / Bank Indonesia / insurance-sector as target categories, source references), document ingestion as engagement configuration; no approval/endorsement/complete-coverage claims in either language (tests + smoke enforce the new boundary)
- Compliance-specific visuals: assessment overview with status bar (tagged Illustrative), gap-analysis chain, remediation-plan extract, report ToC, brutal before/after with time outcomes
- Six workflow steps → four icon-led stages; copy reduced across every section
- Darker burnt-orange solids (brand-800), halved glow peaks, cream-200 form fields
- Both locales rewritten natively to equal density with practice vocabulary
- 344 Playwright tests green on WebKit + Chromium, incl. a new scan-level concepts test

🤖 Generated with [Claude Code](https://claude.com/claude-code)