### PR TITLE
Flatten the SecurePuls Indonesia experience; demonstration-wedge CTA

### DIFF
--- a/qa-mobile/prod-smoke.mjs
+++ b/qa-mobile/prod-smoke.mjs
@@ -47,13 +47,13 @@ const FORBIDDEN_CLAIMS = [
      no specific instrument (POJK/SEOJK, UU PDP) or non-target regulator may
      be named. */
   { re: /\b(tersertifikasi|terakreditasi|kepatuhan otomatis)\b/i, why: "certification claim (id)" },
-  { re: /\bdisetujui\s+(?:oleh\s+)?(OJK|Bank Indonesia|regulator)\b/i, why: "endorsement claim (id)" },
+  { re: /\bdisetujui\s+(?:oleh\s+)?(OJK|Bank Indonesia|PPATK|regulator)\b/i, why: "endorsement claim (id)" },
   { re: /\bmenjamin\s+kepatuhan\b/i, why: "compliance guarantee (id)" },
-  { re: /\b(?:OJK|Bank Indonesia)[- ]approved\b/i, why: "regulator-approval claim" },
-  { re: /\b(?:approved|endorsed|licensed)\s+by\s+(?:OJK|Bank Indonesia)\b/i, why: "regulator-approval claim" },
+  { re: /\b(?:OJK|Bank Indonesia|PPATK)[- ]approved\b/i, why: "regulator-approval claim" },
+  { re: /\b(?:approved|endorsed|licensed)\s+by\s+(?:OJK|Bank Indonesia|PPATK)\b/i, why: "regulator-approval claim" },
   { re: /\b(?:complete|full)\s+coverage\b/i, why: "complete-coverage claim" },
   { re: /\bcakupan\s+(?:penuh|lengkap|menyeluruh)\b/i, why: "complete-coverage claim (id)" },
-  { re: /\b(PPATK|POJK|SEOJK|Kominfo)\b/, why: "named regulator/instrument outside the corpus framing" },
+  { re: /\b(POJK|SEOJK|Kominfo)\b/, why: "named instrument/regulator outside the corpus framing" },
   { re: /\b(UU\s?PDP|PDP Law)\b/i, why: "named Indonesian regulation" },
 ];
 

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -68,10 +68,13 @@ export async function POST(request: Request) {
   const orgType = clean(payload.orgType, 60);
   const locale = clean(payload.locale, 8);
 
+  /* 12 rather than 40: the SecurePuls Indonesia form asks for one workflow
+     in a few words ("policy review" must pass). The company form still asks
+     for more client-side; this is the floor, not the ask. */
   if (
     !name ||
     !company ||
-    work.length < 40 ||
+    work.length < 12 ||
     !/^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(email)
   ) {
     return NextResponse.json({ ok: false, reason: "invalid" }, { status: 422 });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -84,6 +84,11 @@
   --color-signal-400: oklch(0.712 0.062 218);
   --color-signal-600: oklch(0.512 0.062 218);
 
+  /* --- Indonesian flag red. Used only by the market-designation mark in
+     the SecurePuls Indonesia chrome — drawn as CSS bands rather than the
+     🇮🇩 emoji, because Windows renders flag emoji as the letters "ID". --- */
+  --color-merah: oklch(0.55 0.2 27);
+
   --color-success-400: oklch(0.762 0.135 152);
   --color-success-600: oklch(0.582 0.126 152);
 
@@ -208,6 +213,22 @@
 }
 
 /**
+ * `coal` is the third surface: the same warm near-neutrals as ink, held one
+ * step lighter. It exists to break the ink → ember → ink → ember alternation
+ * that made every section change an orange event — a page can now step
+ * between true black and warm charcoal, and reserve ember for the few
+ * moments that earn it. Only the grounds and borders shift; type, accent and
+ * field tokens inherit the ink values from `:root`.
+ */
+[data-surface="coal"] {
+  --surface: var(--color-ink-900);
+  --surface-raised: var(--color-ink-850);
+  --surface-inset: var(--color-ink-950);
+  --border: var(--color-ink-700);
+  --border-strong: var(--color-ink-600);
+}
+
+/**
  * The ember surface inverts one thing about the ink one: the accent cannot be
  * the brand orange, because the ground already is. Orange-on-orange is a
  * ~1.4:1 button. So on ember the accent runs to the *light* end of the same
@@ -249,16 +270,17 @@
    * typed characters at speed. Tinted the same as the ground it sits on, the
    * edge went soft and the whole form read as one brown block.
    *
-   * Warm cream rather than pure white, from founder review: a #fff sheet on a
-   * dark page read as a flash. cream-200 keeps the field unmistakably the
-   * light, interactive object on the surface while sitting in the site's own
-   * warm range — near-black type on it still clears 10:1, and the placeholder
-   * (ink-600) clears 4.5:1.
+   * Warm paper rather than white, twice revised by founder review: #fff read
+   * as a flash, and cream-200 was still "a giant white rectangle". cream-300
+   * is a subdued warm sheet that still reads as the interactive object on the
+   * surface — near-black type on it clears ~12:1, the ink-700 placeholder
+   * ~8:1, and the ink-500 border keeps a visible edge (~3:1) so the field
+   * never dissolves into the ground.
    */
-  --field: var(--color-cream-200);
+  --field: var(--color-cream-300);
   --field-fg: var(--color-ink-950);
-  --field-placeholder: var(--color-ink-600);
-  --field-border: var(--color-ink-400);
+  --field-placeholder: var(--color-ink-700);
+  --field-border: var(--color-ink-500);
   --field-border-focus: var(--color-brand-600);
 }
 

--- a/src/components/indonesia/chrome.tsx
+++ b/src/components/indonesia/chrome.tsx
@@ -33,17 +33,22 @@ export function IndoHeader({ content }: { content: IndoContent }) {
           <KaibreWordmark className="h-7 w-auto text-fg" />
         </Link>
 
-        {/* The product identity. Hidden on the narrowest screens — the hero
-            states it a viewport later, and the wordmark plus toggle already
+        {/* The product and its market, on the wordmark's own centreline: a
+            hairline divider, the product name, and the market designation.
+            The flag is drawn as CSS bands rather than the 🇮🇩 emoji, which
+            Windows renders as the letters "ID"; the visible word "Indonesia"
+            is the accessible name, so the mark itself stays decorative.
+            Hidden on the narrowest screens — the wordmark and toggle already
             fill 320px. */}
-        <span className="hidden items-baseline gap-2 sm:inline-flex">
-          <span aria-hidden className="text-fg-subtle">
-            /
-          </span>
-          <span className="text-heading-2 font-medium text-fg">
+        <span className="hidden items-center gap-3 sm:flex">
+          <span aria-hidden className="h-6 w-px shrink-0 bg-border-strong" />
+          <span className="text-body font-medium leading-none text-fg">
             <SecurePulsName animate={false} />
           </span>
-          <span className="text-small text-fg-subtle">{chrome.marketLabel}</span>
+          <span className="flex items-center gap-1.5 leading-none text-small text-fg-subtle">
+            <IndonesiaFlag />
+            {chrome.marketLabel}
+          </span>
         </span>
 
         <div className="ml-auto flex items-center gap-3 sm:gap-4">
@@ -63,6 +68,23 @@ export function IndoHeader({ content }: { content: IndoContent }) {
         </div>
       </div>
     </header>
+  );
+}
+
+/**
+ * The Indonesian flag as two CSS bands — deterministic on every platform,
+ * unlike the flag emoji, which Windows renders as the letters "ID". Sized to
+ * the small-text cap height so it sits on the market label's own line.
+ */
+function IndonesiaFlag() {
+  return (
+    <span
+      aria-hidden
+      className="inline-flex h-3 w-[18px] shrink-0 flex-col overflow-hidden rounded-[2px] border border-border-strong"
+    >
+      <span className="h-1/2 bg-merah" />
+      <span className="h-1/2 bg-white" />
+    </span>
   );
 }
 

--- a/src/components/indonesia/contact-form.tsx
+++ b/src/components/indonesia/contact-form.tsx
@@ -92,7 +92,9 @@ export function IndoContactForm({
     if (!fields.email) next.email = form.email.errorMissing;
     else if (!isEmail(fields.email)) next.email = form.email.errorInvalid;
     if (!fields.company) next.company = form.company.error;
-    if (fields.work.length < 40) next.work = form.need.error;
+    /* The demonstration wedge asks for one workflow, not a briefing — a few
+       words ("policy review") must be enough to start the conversation. */
+    if (fields.work.length < 12) next.work = form.need.error;
 
     setErrors(next);
     if (Object.keys(next).length > 0) {

--- a/src/components/indonesia/experience.tsx
+++ b/src/components/indonesia/experience.tsx
@@ -70,8 +70,7 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
           <Container>
             <div className="grid grid-cols-[minmax(0,1fr)] items-center gap-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)] lg:gap-16">
               <div>
-                <p className="max-w-[52ch] text-body text-fg-subtle">{c.hero.kicker}</p>
-                <Heading level={1} size="display-1" className="mt-4 max-w-[26ch]">
+                <Heading level={1} size="display-1" className="max-w-[26ch]">
                   {c.hero.headline}
                 </Heading>
                 <Text size="lead" className="mt-6 max-w-[58ch]">
@@ -83,18 +82,12 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
                     {c.hero.secondary.label}
                   </ArrowLink>
                 </div>
-                <p className="mt-5 max-w-[52ch] text-fine text-fg-subtle">
-                  {c.hero.timingNote}
-                </p>
               </div>
 
               <div>
                 <VisualFrame label={c.hero.panel.alt}>
                   <AssessmentOverview panel={c.hero.panel} />
                 </VisualFrame>
-                <p className="mt-3 text-fine text-fg-subtle">
-                  {c.hero.illustrationNote}
-                </p>
               </div>
             </div>
           </Container>
@@ -118,7 +111,7 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
         </Section>
 
         {/* Workflow — four stages, icon-led, glanceable. */}
-        <Section surface="ink" id="workflow">
+        <Section surface="coal" id="workflow">
           <Container>
             <SectionHeader heading={c.workflow.heading} />
             <StageGrid stages={c.workflow.stages} />
@@ -126,7 +119,7 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
         </Section>
 
         {/* Gap analysis and the evidence trail. */}
-        <Section surface="ember">
+        <Section surface="ink">
           <Container>
             <SectionHeader heading={c.trace.heading} body={c.trace.body} />
             <div className="mt-12 grid grid-cols-[minmax(0,1fr)] gap-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)] lg:gap-20">
@@ -151,7 +144,7 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
         </Section>
 
         {/* Deliverables — the remediation plan and the report, shown. */}
-        <Section surface="ink">
+        <Section surface="coal">
           <Container>
             <SectionHeader heading={c.deliverables.heading} />
             <div className="mt-12 grid grid-cols-[minmax(0,1fr)] items-start gap-10 lg:grid-cols-[minmax(0,1.25fr)_minmax(0,1fr)] lg:gap-14">
@@ -162,7 +155,7 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
         </Section>
 
         {/* Before / after, and who decides. */}
-        <Section surface="ember">
+        <Section surface="ink">
           <Container>
             <SectionHeader heading={c.comparison.heading} />
             <div className="mt-12">
@@ -178,7 +171,7 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
         </Section>
 
         {/* Use cases — banks, fintechs, insurers. */}
-        <Section surface="ink">
+        <Section surface="coal">
           <Container>
             <SectionHeader heading={c.useCases.heading} />
             <div className="mt-12 grid grid-cols-[minmax(0,1fr)] gap-10 sm:grid-cols-2 lg:grid-cols-3 lg:gap-8">
@@ -190,7 +183,7 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
                       <li key={item} className="flex gap-3 text-body text-fg-muted">
                         <span
                           aria-hidden
-                          className="mt-2.5 size-1 shrink-0 rounded-full bg-accent"
+                          className="mt-2.5 size-1 shrink-0 rounded-full bg-border-strong"
                         />
                         {item}
                       </li>
@@ -203,7 +196,7 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
         </Section>
 
         {/* The Indonesian deployment — corpus, ingestion, environment. */}
-        <Section surface="ink" className="border-t border-border">
+        <Section surface="ink">
           <Container>
             <SectionHeader heading={c.indonesia.heading} />
             <dl className="mt-12 grid grid-cols-[minmax(0,1fr)] gap-px overflow-hidden rounded-card border border-border bg-border sm:grid-cols-2">

--- a/src/components/indonesia/visuals.tsx
+++ b/src/components/indonesia/visuals.tsx
@@ -80,48 +80,22 @@ export function AssessmentOverview({
         </p>
       </div>
 
-      <p className="mt-4 flex items-baseline gap-3">
-        <span className="font-mono text-display-2 text-fg">
-          {panel.headline.value}
-        </span>
-        <span className="text-small text-fg-muted">{panel.headline.label}</span>
-      </p>
-
-      {/* Status distribution: one stacked bar, then its legend. */}
-      <div
-        aria-hidden
-        className="mt-4 flex h-2 gap-px overflow-hidden rounded-pill"
-      >
-        {panel.bar.map((seg) => (
-          <span
-            key={seg.label}
-            style={{ flexGrow: seg.count }}
-            className={cn("min-w-1", TONE_FILL[seg.tone])}
-          />
-        ))}
-      </div>
-      <ul className="mt-3 flex flex-wrap gap-x-5 gap-y-1.5">
-        {panel.bar.map((seg) => (
-          <li key={seg.label} className="flex items-center gap-2 text-small text-fg-muted">
-            <span aria-hidden className={cn("size-1.5 rounded-full", TONE_FILL[seg.tone])} />
-            {seg.label}
-            <span className="font-mono text-label text-fg-subtle">{seg.count}</span>
-          </li>
-        ))}
-      </ul>
-
-      <ul className="mt-5 space-y-3 border-t border-border pt-4">
+      {/* One hierarchy level: uniform label → value rows. The dot carries the
+          state; nothing else is annotated. */}
+      <ul className="mt-5">
         {panel.rows.map((row, i) => (
-          <li key={row.label} className="flex items-center gap-2.5 text-small text-fg">
-            <PulseDot tone={row.tone} delay={i * 320} />
-            {row.label}
+          <li
+            key={row.label}
+            className="flex items-baseline justify-between gap-4 border-t border-border py-3 first:border-t-0"
+          >
+            <span className="text-body text-fg-muted">{row.label}</span>
+            <span className="flex shrink-0 items-center gap-2 text-body text-fg">
+              <PulseDot tone={row.tone} delay={i * 320} />
+              {row.value}
+            </span>
           </li>
         ))}
       </ul>
-
-      <p className="mt-5 border-t border-border pt-4 text-fine text-fg-subtle">
-        {panel.footnote}
-      </p>
     </div>
   );
 }
@@ -194,15 +168,13 @@ export function StageGrid({
         const Icon = ICONS[stage.icon];
         return (
           <li key={stage.n}>
-            <div className="flex items-center gap-3">
-              <span
-                aria-hidden
-                className="flex size-10 items-center justify-center rounded-control border border-border-strong text-accent"
-              >
-                <Icon className="size-5" />
-              </span>
-              <span className="font-mono text-label text-fg-subtle">{stage.n}</span>
-            </div>
+            {/* Icon, name, one sentence — three things, no numbering row. */}
+            <span
+              aria-hidden
+              className="flex size-10 items-center justify-center rounded-control border border-border-strong text-fg-muted"
+            >
+              <Icon className="size-5" />
+            </span>
             <h3 className="mt-4 text-heading-1 text-fg">{stage.title}</h3>
             <p className="mt-2 max-w-[36ch] text-body text-fg-muted">{stage.body}</p>
           </li>
@@ -249,11 +221,18 @@ export function TraceChain({
               <div className={cn(!last && "pb-5")}>
                 <p className="text-small text-fg-subtle">{node.label}</p>
                 <p className="mt-1 text-body text-fg">{node.text}</p>
-                {node.meta ? (
-                  <p className="mt-1.5 font-mono text-label tracking-[0.02em] text-accent">
-                    {node.meta}
-                  </p>
-                ) : null}
+                {/* Mono reference line. Quiet by default — the accented node
+                    halo already marks where the meaning sits, and a page of
+                    orange metadata reads as noise. */}
+                <p
+                  className={cn(
+                    "mt-1.5 font-mono text-label tracking-[0.02em]",
+                    node.accent ? "text-accent" : "text-fg-subtle",
+                    !node.meta && "hidden",
+                  )}
+                >
+                  {node.meta}
+                </p>
               </div>
             </li>
           );
@@ -279,11 +258,19 @@ export function RemediationTable({
 }: {
   content: IndoContent["deliverables"]["remediation"];
 }) {
-  const { columns, rows, caption } = content;
+  const { columns, rows, title, tag } = content;
 
   return (
-    <figure>
-      <div className="overflow-hidden rounded-card border border-border bg-surface-raised">
+    <div>
+      {/* Flat: the deliverable's own name, one small illustrative marker,
+          then the table. No "extract", no caption row, no footer. */}
+      <h3 className="flex items-baseline gap-3">
+        <span className="text-heading-2 text-fg">{title}</span>
+        <span className="font-mono text-label uppercase tracking-[0.085em] text-fg-subtle">
+          {tag}
+        </span>
+      </h3>
+      <div className="mt-4 overflow-hidden rounded-card border border-border bg-surface-raised">
         {/* Table layout from `sm` up. */}
         <div className="hidden sm:block">
           <div className="grid grid-cols-[minmax(0,1.3fr)_auto_minmax(0,1.5fr)_auto] gap-x-5 border-b border-border px-5 py-3">
@@ -334,8 +321,7 @@ export function RemediationTable({
           ))}
         </ul>
       </div>
-      <figcaption className="mt-3 text-fine text-fg-subtle">{caption}</figcaption>
-    </figure>
+    </div>
   );
 }
 
@@ -352,27 +338,24 @@ export function ReportPreview({
   content: IndoContent["deliverables"]["report"];
 }) {
   return (
-    <figure>
-      <div className="rounded-card border border-border bg-surface-raised p-6 sm:p-7">
-        <p className="border-b border-border-strong pb-4 text-heading-2 text-fg">
-          {content.title}
-        </p>
-        <ol className="mt-4 space-y-2.5">
-          {content.sections.map((section, i) => (
-            <li key={section} className="flex items-baseline gap-3">
-              <span className="font-mono text-label text-fg-subtle">
-                {String(i + 1).padStart(2, "0")}
-              </span>
-              <span className="text-body text-fg-muted">{section}</span>
-              <span aria-hidden className="mb-1 flex-1 self-end border-b border-dotted border-border" />
-            </li>
-          ))}
-        </ol>
-      </div>
-      <figcaption className="mt-3 text-fine text-fg-subtle">
-        {content.caption}
-      </figcaption>
-    </figure>
+    /* The document explains itself: its own title, then its contents. No
+       caption underneath repeating what the title already says. */
+    <div className="rounded-card border border-border bg-surface-raised p-6 sm:p-7">
+      <p className="border-b border-border-strong pb-4 text-heading-2 text-fg">
+        {content.title}
+      </p>
+      <ol className="mt-4 space-y-2.5">
+        {content.sections.map((section, i) => (
+          <li key={section} className="flex items-baseline gap-3">
+            <span className="font-mono text-label text-fg-subtle">
+              {String(i + 1).padStart(2, "0")}
+            </span>
+            <span className="text-body text-fg-muted">{section}</span>
+            <span aria-hidden className="mb-1 flex-1 self-end border-b border-dotted border-border" />
+          </li>
+        ))}
+      </ol>
+    </div>
   );
 }
 

--- a/src/components/primitives/index.tsx
+++ b/src/components/primitives/index.tsx
@@ -6,7 +6,7 @@ import { withBrand } from "@/components/visuals";
    Layout primitives
    ========================================================================== */
 
-type Surface = "ink" | "ember";
+type Surface = "ink" | "ember" | "coal";
 
 interface SectionProps {
   children: ReactNode;

--- a/src/content/indonesia/en.ts
+++ b/src/content/indonesia/en.ts
@@ -35,34 +35,25 @@ export const EN: IndoContent = {
     kaibreHome: "Kaibre — company site",
     marketLabel: "Indonesia",
     toggle: { navLabel: "Language", en: "English", id: "Bahasa Indonesia" },
-    cta: { label: "Discuss an assessment", href: "#contact" },
+    cta: { label: "Show us a workflow", href: "#contact" },
   },
   hero: {
-    kicker: "AI-assisted compliance assessment, for banks, fintechs and insurers in Indonesia",
     headline: "Compliance assessment drafts in about 30 minutes, not weeks.",
-    body: "SecurePuls reads the regulatory corpus configured for the engagement alongside your policies and evidence, maps each requirement to its evidence, drafts the gap analysis — severity-ranked findings, remediation plan — and produces a review-ready draft report. Your reviewers verify and sign off.",
-    timingNote:
-      "Timing varies with assessment scope, evidence volume, and configuration.",
-    cta: { label: "Discuss an assessment", href: "#contact" },
-    secondary: { label: "See the workflow", href: "#workflow" },
+    body: "SecurePuls AI turns the regulatory requirements, policies and evidence of an Indonesian financial institution into a gap analysis, remediation plan and review-ready draft — verified and signed off by your reviewers. Timing varies with scope, evidence volume and configuration.",
+    cta: { label: "Show us a workflow", href: "#contact" },
+    secondary: { label: "How it works", href: "#workflow" },
     panel: {
-      alt: "Illustrative assessment overview: requirements assessed, their status distribution, open findings, and review state.",
+      alt: "Illustrative assessment snapshot: requirements assessed, gaps found, severity, remediation state, and review state.",
       tag: "Illustrative",
-      caption: "Regulatory assessment — banking",
-      headline: { value: "42", label: "requirements assessed" },
-      bar: [
-        { label: "Compliant", count: 31, tone: "positive" },
-        { label: "Partial", count: 6, tone: "neutral" },
-        { label: "Gap", count: 5, tone: "attention" },
-      ],
+      caption: "Assessment",
       rows: [
-        { label: "5 findings — 1 critical, 2 high", tone: "attention" },
-        { label: "Evidence mapped to sources", tone: "positive" },
-        { label: "Awaiting reviewer verification", tone: "neutral" },
+        { label: "Requirements assessed", value: "42", tone: "neutral" },
+        { label: "Gap analysis", value: "5 gaps", tone: "attention" },
+        { label: "High severity", value: "2 findings", tone: "attention" },
+        { label: "Remediation plan", value: "Ready", tone: "positive" },
+        { label: "Reviewer", value: "Pending verification", tone: "neutral" },
       ],
-      footnote: "Findings stay drafts until the designated reviewer signs off.",
     },
-    illustrationNote: "Interface illustration.",
   },
   inOut: {
     heading: "What goes in. What comes out.",
@@ -72,7 +63,7 @@ export const EN: IndoContent = {
         {
           icon: "corpus",
           label: "The applicable regulatory corpus",
-          note: "curated and configured for the engagement",
+          note: "curated and maintained by Kaibre — not rebuilt by your team",
         },
         { icon: "policy", label: "Internal policies and procedures" },
         { icon: "evidence", label: "Supporting evidence and documentation" },
@@ -104,7 +95,7 @@ export const EN: IndoContent = {
         n: "02",
         icon: "assess",
         title: "Assess",
-        body: "AI maps requirements to evidence and drafts the gap analysis.",
+        body: "SecurePuls AI maps requirements to evidence and drafts the gap analysis.",
       },
       {
         n: "03",
@@ -126,26 +117,26 @@ export const EN: IndoContent = {
     chain: [
       {
         label: "Regulatory requirement",
-        text: "Access rights to customer data are reviewed on a defined schedule.",
+        text: "Access to customer data must be restricted to authorised roles.",
       },
       {
         label: "Evidence found",
-        text: "Policy requires quarterly reviews — no review records for the two most recent quarters.",
-        meta: "Source: access-management policy, review section",
+        text: "Policy defines role-based access — periodic access-review records are incomplete.",
+        meta: "Source: access-management policy",
       },
       {
-        label: "Gap",
-        text: "Periodic access reviews not evidenced.",
+        label: "Assessment",
+        text: "Partial — access reviews not evidenced.",
         meta: "Severity: High",
         accent: true,
       },
       {
         label: "Remediation",
-        text: "Reinstate the review cycle and retain sign-off records.",
+        text: "Implement periodic access reviews with named ownership and retained records.",
       },
       {
-        label: "Reviewer verification",
-        text: "Confirmed by the designated reviewer.",
+        label: "Reviewer",
+        text: "Pending verification.",
       },
     ],
     caption: "Illustrative example — not drawn from any specific regulation.",
@@ -172,7 +163,8 @@ export const EN: IndoContent = {
   deliverables: {
     heading: "What you receive.",
     remediation: {
-      caption: "Remediation plan — extract. Illustrative.",
+      title: "Remediation plan",
+      tag: "Illustrative",
       columns: {
         finding: "Finding",
         severity: "Severity",
@@ -204,14 +196,14 @@ export const EN: IndoContent = {
       ],
     },
     report: {
-      caption: "Draft report — structure",
       title: "Compliance assessment report",
       sections: [
         "Executive summary",
+        "Requirement assessment",
         "Gap analysis",
         "Findings and severity",
         "Remediation plan",
-        "Source references",
+        "Evidence and source references",
         "Reviewer sign-off",
       ],
     },
@@ -233,7 +225,7 @@ export const EN: IndoContent = {
       title: "With SecurePuls",
       steps: [
         "Corpus, policies and evidence in one place",
-        "AI-assisted assessment",
+        "SecurePuls AI drafts the assessment",
         "Gap analysis and remediation plan",
         "Reviewer verification",
         "Review-ready draft report",
@@ -255,17 +247,17 @@ export const EN: IndoContent = {
       {
         title: "Banks",
         items: [
-          "Recurring regulatory and internal control assessments",
-          "Policy-to-requirement mapping with control gap analysis",
-          "Evidence-backed findings and remediation tracking",
+          "Recurring regulatory assessments",
+          "Control gap analysis",
+          "Evidence-backed findings",
         ],
       },
       {
         title: "Fintechs",
         items: [
-          "Regulatory readiness ahead of a licensing step or review",
-          "Evidence kept current through rapid product change",
-          "Policy and control assessment with gap remediation",
+          "Regulatory readiness",
+          "Policy and control assessment",
+          "Remediation during rapid product change",
         ],
       },
       {
@@ -273,7 +265,7 @@ export const EN: IndoContent = {
         items: [
           "Regulatory obligation assessment",
           "Governance and policy review",
-          "Recurring compliance reporting with findings and remediation",
+          "Recurring findings and remediation reporting",
         ],
       },
     ],
@@ -283,7 +275,7 @@ export const EN: IndoContent = {
     items: [
       {
         title: "Curated Indonesian regulatory knowledge base",
-        note: "Indonesian deployments are configured with the regulatory corpus for the engagement — OJK, Bank Indonesia and insurance-sector requirements as applicable — with source references.",
+        note: "Configured with the corpus applicable to the institution and assessment scope — OJK, Bank Indonesia, PPATK and insurance-sector requirements as relevant — curated, verified and maintained as part of the deployment.",
       },
       {
         title: "Document ingestion for the engagement",
@@ -294,15 +286,15 @@ export const EN: IndoContent = {
         note: "Its own database, administrator-created accounts, no public sign-up — and it can be operated inside your environment.",
       },
       {
-        title: "Configurable model endpoint",
-        note: "Analysis can run against an approved, OpenAI-compatible endpoint.",
+        title: "Configurable AI model deployment",
+        note: "Analysis runs on a model deployment your institution approves and controls.",
       },
     ],
     note: "SecurePuls does not claim regulator approval. Corpus coverage is scoped and verified per engagement.",
   },
   contact: {
-    heading: "Discuss an assessment.",
-    body: "Tell us which requirements your team assesses against and who reviews the result. It reaches the people building SecurePuls.",
+    heading: "Bring us one compliance workflow.",
+    body: "Show us one assessment your team handles manually — we will demonstrate how SecurePuls structures the evidence, gap analysis, remediation plan and review-ready draft. The initial demonstration costs nothing.",
     form: {
       name: { label: "Name", error: "Please add your name." },
       email: {
@@ -323,17 +315,17 @@ export const EN: IndoContent = {
         ],
       },
       need: {
-        label: "Tell us about the assessment need",
-        hint: "Which requirements does your team assess against, how often, and who reviews the result?",
+        label: "What compliance workflow would you like to test?",
+        hint: "One line is enough.",
         placeholder:
-          "e.g. We run recurring internal control assessments across several entities. Requirements live in spreadsheets, evidence in shared folders, and two reviewers assemble the report by hand each cycle.",
-        error: "A sentence or two more, so we can give you a useful reply.",
+          "e.g. a recurring regulatory assessment, a policy review, a control gap analysis",
+        error: "A few words about the workflow, so we can prepare a relevant demonstration.",
       },
       submit: "Send it",
       sending: "Sending…",
       sent: {
         heading: "Thanks — that reached us.",
-        body: "Your message is in our inbox. You will hear back from the people building SecurePuls.",
+        body: "Your message is in our inbox. The people building SecurePuls will come back to you to arrange the demonstration.",
       },
       fallback: {
         heading: "One more step.",

--- a/src/content/indonesia/id.ts
+++ b/src/content/indonesia/id.ts
@@ -32,36 +32,25 @@ export const ID: IndoContent = {
     kaibreHome: "Kaibre — situs perusahaan",
     marketLabel: "Indonesia",
     toggle: { navLabel: "Bahasa", en: "English", id: "Bahasa Indonesia" },
-    cta: { label: "Diskusikan asesmen", href: "#contact" },
+    cta: { label: "Tunjukkan alur kerja", href: "#contact" },
   },
   hero: {
-    kicker:
-      "Asesmen kepatuhan berbantuan AI — untuk bank, fintech, dan perusahaan asuransi di Indonesia",
     headline: "Draf asesmen kepatuhan dalam sekitar 30 menit, bukan berminggu-minggu.",
-    body: "SecurePuls membaca korpus regulasi yang dikonfigurasi untuk penugasan beserta kebijakan dan bukti institusi Anda, memetakan setiap ketentuan ke buktinya, menyusun analisis kesenjangan — temuan berperingkat keparahan, rencana remediasi — dan menghasilkan draf laporan siap telaah. Penelaah Anda memverifikasi dan mengesahkannya.",
-    timingNote:
-      "Durasi bervariasi menurut cakupan asesmen, volume bukti, dan konfigurasi.",
-    cta: { label: "Diskusikan asesmen Anda", href: "#contact" },
-    secondary: { label: "Lihat alur kerjanya", href: "#workflow" },
+    body: "SecurePuls AI mengubah ketentuan regulasi, kebijakan, dan bukti lembaga jasa keuangan Indonesia menjadi analisis kesenjangan, rencana remediasi, dan draf siap telaah — diverifikasi dan disahkan oleh penelaah Anda. Durasi bervariasi menurut cakupan, volume bukti, dan konfigurasi.",
+    cta: { label: "Tunjukkan alur kerja Anda", href: "#contact" },
+    secondary: { label: "Cara kerjanya", href: "#workflow" },
     panel: {
-      alt: "Ikhtisar asesmen ilustratif: jumlah ketentuan yang dinilai, distribusi statusnya, temuan terbuka, dan status telaah.",
+      alt: "Cuplikan asesmen ilustratif: ketentuan yang dinilai, kesenjangan yang ditemukan, keparahan, status remediasi, dan status telaah.",
       tag: "Ilustratif",
-      caption: "Asesmen regulasi — perbankan",
-      headline: { value: "42", label: "ketentuan dinilai" },
-      bar: [
-        { label: "Patuh", count: 31, tone: "positive" },
-        { label: "Parsial", count: 6, tone: "neutral" },
-        { label: "Gap", count: 5, tone: "attention" },
-      ],
+      caption: "Asesmen",
       rows: [
-        { label: "5 temuan — 1 kritis, 2 tinggi", tone: "attention" },
-        { label: "Bukti terpetakan ke sumbernya", tone: "positive" },
-        { label: "Menunggu verifikasi penelaah", tone: "neutral" },
+        { label: "Ketentuan dinilai", value: "42", tone: "neutral" },
+        { label: "Analisis kesenjangan", value: "5 gap", tone: "attention" },
+        { label: "Keparahan tinggi", value: "2 temuan", tone: "attention" },
+        { label: "Rencana remediasi", value: "Siap", tone: "positive" },
+        { label: "Penelaah", value: "Menunggu verifikasi", tone: "neutral" },
       ],
-      footnote:
-        "Temuan tetap berupa draf sampai disahkan oleh penelaah yang ditunjuk.",
     },
-    illustrationNote: "Ilustrasi antarmuka.",
   },
   inOut: {
     heading: "Apa yang masuk. Apa yang keluar.",
@@ -71,7 +60,7 @@ export const ID: IndoContent = {
         {
           icon: "corpus",
           label: "Korpus regulasi yang berlaku",
-          note: "dikurasi dan dikonfigurasi untuk penugasan",
+          note: "dikurasi dan dipelihara oleh Kaibre — tidak disusun ulang oleh tim Anda",
         },
         { icon: "policy", label: "Kebijakan dan prosedur internal" },
         { icon: "evidence", label: "Bukti dan dokumentasi pendukung" },
@@ -103,7 +92,7 @@ export const ID: IndoContent = {
         n: "02",
         icon: "assess",
         title: "Asesmen",
-        body: "AI memetakan ketentuan ke bukti dan menyusun analisis kesenjangannya.",
+        body: "SecurePuls AI memetakan ketentuan ke bukti dan menyusun analisis kesenjangannya.",
       },
       {
         n: "03",
@@ -125,26 +114,26 @@ export const ID: IndoContent = {
     chain: [
       {
         label: "Ketentuan regulasi",
-        text: "Hak akses ke data nasabah ditinjau sesuai jadwal yang ditetapkan.",
+        text: "Akses ke data nasabah wajib dibatasi sesuai peran yang berwenang.",
       },
       {
         label: "Bukti yang ditemukan",
-        text: "Kebijakan mewajibkan tinjauan triwulanan — tidak ada catatan tinjauan untuk dua triwulan terakhir.",
-        meta: "Sumber: kebijakan manajemen akses, bagian peninjauan",
+        text: "Kebijakan menetapkan akses berbasis peran — catatan tinjauan akses berkala tidak lengkap.",
+        meta: "Sumber: kebijakan manajemen akses",
       },
       {
-        label: "Kesenjangan (gap)",
-        text: "Tinjauan akses berkala tidak terbukti dilaksanakan.",
+        label: "Asesmen",
+        text: "Parsial — tinjauan akses tidak terbukti dilaksanakan.",
         meta: "Keparahan: Tinggi",
         accent: true,
       },
       {
         label: "Remediasi",
-        text: "Pulihkan siklus tinjauan dan simpan catatan pengesahannya.",
+        text: "Terapkan tinjauan akses berkala dengan penanggung jawab yang ditunjuk dan catatan yang tersimpan.",
       },
       {
-        label: "Verifikasi penelaah",
-        text: "Dikonfirmasi oleh penelaah yang ditunjuk.",
+        label: "Penelaah",
+        text: "Menunggu verifikasi.",
       },
     ],
     caption: "Contoh ilustratif — tidak diambil dari regulasi tertentu.",
@@ -171,7 +160,8 @@ export const ID: IndoContent = {
   deliverables: {
     heading: "Yang Anda terima.",
     remediation: {
-      caption: "Rencana remediasi — cuplikan. Ilustratif.",
+      title: "Rencana remediasi",
+      tag: "Ilustratif",
       columns: {
         finding: "Temuan",
         severity: "Keparahan",
@@ -203,14 +193,14 @@ export const ID: IndoContent = {
       ],
     },
     report: {
-      caption: "Draf laporan — struktur",
       title: "Laporan asesmen kepatuhan",
       sections: [
         "Ringkasan eksekutif",
+        "Asesmen ketentuan",
         "Analisis kesenjangan",
         "Temuan dan keparahan",
         "Rencana remediasi",
-        "Rujukan sumber",
+        "Bukti dan rujukan sumber",
         "Pengesahan penelaah",
       ],
     },
@@ -232,7 +222,7 @@ export const ID: IndoContent = {
       title: "Dengan SecurePuls",
       steps: [
         "Korpus, kebijakan, dan bukti dalam satu tempat",
-        "Asesmen berbantuan AI",
+        "SecurePuls AI menyusun asesmennya",
         "Analisis kesenjangan dan rencana remediasi",
         "Verifikasi penelaah",
         "Draf laporan siap telaah",
@@ -254,17 +244,17 @@ export const ID: IndoContent = {
       {
         title: "Bank",
         items: [
-          "Asesmen berkala atas ketentuan regulasi dan pengendalian internal",
-          "Pemetaan kebijakan ke ketentuan dengan analisis kesenjangan pengendalian",
-          "Temuan berbasis bukti dan pemantauan remediasi",
+          "Asesmen regulasi berkala",
+          "Analisis kesenjangan pengendalian",
+          "Temuan berbasis bukti",
         ],
       },
       {
         title: "Fintech",
         items: [
-          "Kesiapan regulasi menjelang perizinan atau tinjauan",
-          "Bukti tetap mutakhir di tengah perubahan produk yang cepat",
-          "Asesmen kebijakan dan pengendalian dengan remediasi kesenjangan",
+          "Kesiapan regulasi",
+          "Asesmen kebijakan dan pengendalian",
+          "Remediasi di tengah perubahan produk yang cepat",
         ],
       },
       {
@@ -272,7 +262,7 @@ export const ID: IndoContent = {
         items: [
           "Asesmen kewajiban regulasi",
           "Tinjauan tata kelola dan kebijakan",
-          "Pelaporan kepatuhan berkala dengan temuan dan remediasinya",
+          "Pelaporan temuan dan remediasi berkala",
         ],
       },
     ],
@@ -282,7 +272,7 @@ export const ID: IndoContent = {
     items: [
       {
         title: "Basis pengetahuan regulasi Indonesia yang terkurasi",
-        note: "Deployment di Indonesia dikonfigurasi dengan korpus regulasi untuk penugasan — ketentuan OJK, Bank Indonesia, dan sektor asuransi sesuai relevansinya — lengkap dengan rujukan sumber.",
+        note: "Dikonfigurasi dengan korpus yang berlaku bagi institusi dan cakupan asesmennya — ketentuan OJK, Bank Indonesia, PPATK, dan sektor asuransi sesuai relevansinya — dikurasi, diverifikasi, dan dipelihara sebagai bagian dari deployment.",
       },
       {
         title: "Pemuatan dokumen untuk penugasan",
@@ -293,15 +283,15 @@ export const ID: IndoContent = {
         note: "Basis data sendiri, akun dibuat administrator, tanpa pendaftaran publik — dan dapat dioperasikan di dalam lingkungan Anda.",
       },
       {
-        title: "Endpoint model dapat dikonfigurasi",
-        note: "Analisis dapat dijalankan pada endpoint kompatibel OpenAI yang Anda setujui.",
+        title: "Deployment model AI dapat dikonfigurasi",
+        note: "Analisis berjalan pada deployment model yang disetujui dan dikendalikan institusi Anda.",
       },
     ],
     note: "SecurePuls tidak mengklaim persetujuan regulator. Cakupan korpus ditetapkan dan diverifikasi per penugasan.",
   },
   contact: {
-    heading: "Diskusikan asesmen Anda.",
-    body: "Sampaikan ketentuan apa yang menjadi acuan asesmen tim Anda dan siapa yang menelaah hasilnya. Pesan Anda sampai langsung ke tim yang membangun SecurePuls.",
+    heading: "Bawakan kami satu alur kerja kepatuhan.",
+    body: "Tunjukkan satu asesmen yang masih dikerjakan tim Anda secara manual — kami akan mendemonstrasikan bagaimana SecurePuls menyusun bukti, analisis kesenjangan, rencana remediasi, dan draf siap telaahnya. Demonstrasi awal tanpa biaya.",
     form: {
       name: { label: "Nama", error: "Mohon isi nama Anda." },
       email: {
@@ -322,18 +312,18 @@ export const ID: IndoContent = {
         ],
       },
       need: {
-        label: "Ceritakan kebutuhan asesmen Anda",
-        hint: "Ketentuan apa yang menjadi acuan asesmen tim Anda, seberapa sering, dan siapa yang menelaah hasilnya?",
+        label: "Alur kerja kepatuhan apa yang ingin Anda uji?",
+        hint: "Satu kalimat pun cukup.",
         placeholder:
-          "cth. Kami menjalankan asesmen pengendalian internal secara berkala di beberapa entitas. Ketentuan tercatat di spreadsheet, bukti tersebar di folder bersama, dan dua penelaah merakit laporannya secara manual setiap siklus.",
+          "cth. asesmen regulasi berkala, tinjauan kebijakan, analisis kesenjangan pengendalian",
         error:
-          "Tambahkan satu-dua kalimat lagi agar kami dapat memberi jawaban yang berguna.",
+          "Tuliskan sedikit tentang alur kerjanya agar kami dapat menyiapkan demonstrasi yang relevan.",
       },
       submit: "Kirim",
       sending: "Mengirim…",
       sent: {
         heading: "Terima kasih — pesan Anda sudah sampai.",
-        body: "Pesan Anda ada di kotak masuk kami. Anda akan mendapat balasan dari tim yang membangun SecurePuls.",
+        body: "Pesan Anda ada di kotak masuk kami. Tim yang membangun SecurePuls akan menghubungi Anda untuk mengatur demonstrasinya.",
       },
       fallback: {
         heading: "Satu langkah lagi.",

--- a/src/content/indonesia/types.ts
+++ b/src/content/indonesia/types.ts
@@ -53,35 +53,23 @@ export interface IndoContent {
     cta: { label: string; href: string };
   };
   hero: {
-    /** The one line above the headline: AI-assisted + who it is for. */
-    kicker: string;
     headline: string;
+    /** One mechanism line. Carries the audience, the AI, the deliverables,
+     *  the human gate, and the timing qualification — one hierarchy level. */
     body: string;
-    /** The restrained qualification of the timing claim. */
-    timingNote: string;
     cta: { label: string; href: string };
     secondary: { label: string; href: string };
+    /** Flat assessment snapshot: caption, illustrative tag, uniform rows. */
     panel: {
       alt: string;
-      /** Corner tag marking the figures as illustrative. */
       tag: string;
       caption: string;
-      /** The headline figure — "42" + "requirements assessed". */
-      headline: { value: string; label: string };
-      /** Stacked distribution bar with its legend. */
-      bar: readonly {
-        label: string;
-        count: number;
-        tone: "positive" | "neutral" | "attention";
-      }[];
-      /** Compact status rows under the bar. */
       rows: readonly {
         label: string;
+        value: string;
         tone: "positive" | "attention" | "neutral";
       }[];
-      footnote: string;
     };
-    illustrationNote: string;
   };
   inOut: {
     heading: string;
@@ -114,7 +102,9 @@ export interface IndoContent {
   deliverables: {
     heading: string;
     remediation: {
-      caption: string;
+      title: string;
+      /** Small inline "Illustrative" marker beside the title. */
+      tag: string;
       columns: { finding: string; severity: string; action: string; target: string };
       rows: readonly {
         finding: string;
@@ -125,7 +115,6 @@ export interface IndoContent {
       }[];
     };
     report: {
-      caption: string;
       title: string;
       sections: readonly string[];
     };

--- a/tests/indonesia.spec.ts
+++ b/tests/indonesia.spec.ts
@@ -75,11 +75,11 @@ const INDONESIAN_MARKERS = /\b(dan|yang|untuk|dengan|kami|adalah|setiap)\b/gi;
  * timing promise.
  */
 const FORBIDDEN = [
-  /\b(PPATK|POJK|SEOJK|Kominfo)\b/,
+  /\b(POJK|SEOJK|Kominfo)\b/,
   /\b(UU\s?PDP|PDP Law)\b/i,
-  /\b(?:OJK|Bank Indonesia)[- ]approved\b/i,
-  /\b(?:approved|endorsed|licensed)\s+by\s+(?:OJK|Bank Indonesia|the regulator)\b/i,
-  /\bdisetujui\s+(?:oleh\s+)?(?:OJK|Bank Indonesia|regulator)\b/i,
+  /\b(?:OJK|Bank Indonesia|PPATK)[- ]approved\b/i,
+  /\b(?:approved|endorsed|licensed)\s+by\s+(?:OJK|Bank Indonesia|PPATK|the regulator)\b/i,
+  /\bdisetujui\s+(?:oleh\s+)?(?:OJK|Bank Indonesia|PPATK|regulator)\b/i,
   /\b(?:complete|full)\s+coverage\b/i,
   /\bcakupan\s+(?:penuh|lengkap|menyeluruh)\b/i,
   /\b(certified|accredited|regulator[- ]approved|guaranteed)\b/i,
@@ -270,7 +270,7 @@ test.describe("regulatory guardrails", () => {
         EN_PATH,
         [
           /about 30 minutes/i,
-          /AI-assisted/i,
+          /SecurePuls AI/,
           /gap analysis/i,
           /remediation plan/i,
           /severity/i,
@@ -278,13 +278,14 @@ test.describe("regulatory guardrails", () => {
           /regulatory corpus/i,
           /OJK/,
           /Bank Indonesia/,
+          /PPATK/,
         ],
       ],
       [
         ID_PATH,
         [
           /sekitar 30 menit/i,
-          /berbantuan AI/i,
+          /SecurePuls AI/,
           /analisis kesenjangan/i,
           /rencana remediasi/i,
           /keparahan/i,
@@ -292,6 +293,7 @@ test.describe("regulatory guardrails", () => {
           /korpus regulasi/i,
           /OJK/,
           /Bank Indonesia/,
+          /PPATK/,
         ],
       ],
     ];
@@ -382,7 +384,7 @@ test.describe("contact form", () => {
   test("the header CTA lands on the form, clear of the sticky header", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
     await page.goto(EN_PATH);
-    await page.getByRole("banner").getByRole("link", { name: "Discuss an assessment" }).click();
+    await page.getByRole("banner").getByRole("link", { name: "Show us a workflow" }).click();
     await page.waitForTimeout(400);
     const m = await page.evaluate(() => {
       const heading = document.querySelector("#contact h2")!;


### PR DESCRIPTION
Founder overnight directive, P0: fewer hierarchy levels, demonstration wedge, surface rhythm, header alignment.

- Hero: 3 text levels + 1 flat panel (was 5 + 7-level illustration); timing qualifier integrated into the mechanism line
- CTA model: "Bring us one compliance workflow" / "Show us a workflow" — free initial demonstration, low-friction workflow field (floor 12 chars, client+server)
- New `coal` surface breaks the black/orange alternation; ember reserved for the in/out moment and conversion
- Orange restraint: neutral workflow icons and list markers, quiet chain metadata; fields darkened to cream-300
- Header brand group on one centreline with a CSS-band Indonesian flag (emoji renders as "ID" on Windows — rejected)
- Bank-specific gap-analysis example (role-based access to customer data, PARTIAL, High, remediation with named ownership)
- Corpus positioned as curated and maintained by Kaibre; PPATK added to target categories; "OpenAI-compatible" removed for "configurable AI model deployment"
- 344 Playwright tests green, WebKit + Chromium

🤖 Generated with [Claude Code](https://claude.com/claude-code)