### PR TITLE
SecurePulse: official naming, document hero, mobile-first density

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ src/
 │  ├─ (site)/              the company site, under the English chrome
 │  │  ├─ layout.tsx        SiteChrome: skip link · header · main · footer
 │  │  ├─ page.tsx          home
-│  │  ├─ securepuls/       product page (UAE physical security)
+│  │  ├─ securepulse/       product page (UAE physical security)
 │  │  ├─ kai/              product page
 │  │  ├─ work/             selected work + commissioned systems
 │  │  └─ contact/          contact form
-│  ├─ securepuls/indonesia/     SecurePuls Indonesia — English
-│  ├─ id/securepuls/indonesia/  SecurePuls Indonesia — Bahasa Indonesia
+│  ├─ securepulse/indonesia/     SecurePulse Indonesia — English
+│  ├─ id/securepulse/indonesia/  SecurePulse Indonesia — Bahasa Indonesia
 │  ├─ robots.ts · sitemap.ts · opengraph-image.tsx
 │  └─ globals.css          the design system (tokens only)
 ├─ content/                ALL copy lives here, as typed objects
@@ -111,10 +111,10 @@ src/
 └─ lib/                    utils · raw-colors
 ```
 
-### SecurePuls Indonesia
+### SecurePulse Indonesia
 
 A bilingual product experience for Indonesian banks, fintechs and insurers:
-`/securepuls/indonesia` (English) and `/id/securepuls/indonesia` (Bahasa
+`/securepulse/indonesia` (English) and `/id/securepulse/indonesia` (Bahasa
 Indonesia). One page component, two typed dictionaries — the
 `IndoContent` interface in `src/content/indonesia/types.ts` is the
 synchronisation guarantee, so a string added to one locale fails the build
@@ -132,7 +132,7 @@ insurance-sector requirements may be named as **target corpus categories
 configured per engagement** — never as approving, endorsing, or completely
 covered, and no specific instrument (POJK/SEOJK, UU PDP) or non-target
 regulator is named. The ~30-minute figure is founder/practitioner-supplied
-evidence from the working SecurePuls workflow reviewed by a senior regulatory
+evidence from the working SecurePulse workflow reviewed by a senior regulatory
 lawyer; it always travels qualified ("about", "for a configured assessment",
 plus the scope/volume/configuration note) and never as an SLA. Illustrative
 figures appear only inside mockups tagged "Illustrative", and the vocabulary

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,10 +11,11 @@ const nextConfig: NextConfig = {
    * email signatures), so each one is permanently redirected to the closest
    * surviving destination rather than 404ing.
    *
-   * /securepulse is the same story for a different reason: the product is
-   * spelled SecurePuls, and the route was corrected to match. Anything already
-   * pointing at the misspelling — links, the search index, a signature — keeps
-   * working.
+   * /securepuls is the naming history: the site shipped for a period under
+   * that spelling before the founders confirmed the official name is
+   * SecurePulse and the routes were corrected to match. Everything that ever
+   * pointed at the old slugs — shared links, the search index, signatures —
+   * keeps working, including the bilingual Indonesia pair.
    */
   async redirects() {
     return [
@@ -23,7 +24,9 @@ const nextConfig: NextConfig = {
       { source: "/projects", destination: "/work", permanent: true },
       { source: "/team", destination: "/", permanent: true },
       { source: "/careers", destination: "/contact", permanent: true },
-      { source: "/securepulse", destination: "/securepuls", permanent: true },
+      { source: "/securepuls", destination: "/securepulse", permanent: true },
+      { source: "/securepuls/:path*", destination: "/securepulse/:path*", permanent: true },
+      { source: "/id/securepuls/:path*", destination: "/id/securepulse/:path*", permanent: true },
     ];
   },
 };

--- a/qa-mobile/audit.mjs
+++ b/qa-mobile/audit.mjs
@@ -38,7 +38,7 @@ const LANDSCAPE = [
   { name: "932x430", width: 932, height: 430, note: "large phone landscape" },
 ];
 
-const ROUTES = ["/", "/securepuls", "/kai", "/work", "/contact"];
+const ROUTES = ["/", "/securepulse", "/kai", "/work", "/contact"];
 
 /**
  * Safari's *small* viewport per device — the height actually visible with the

--- a/qa-mobile/crops.mjs
+++ b/qa-mobile/crops.mjs
@@ -9,8 +9,8 @@ const b = await webkit.launch();
 const shots = [
   ["/", "h1", "home-hero", 375, 812],
   ["/", "#products", "home-products", 390, 844],
-  ["/securepuls", 'div[role="img"][aria-label^="A draft finding"]', "sp-evidence", 375, 812],
-  ["/securepuls", "h1", "sp-hero", 375, 812],
+  ["/securepulse", 'div[role="img"][aria-label^="A draft finding"]', "sp-evidence", 375, 812],
+  ["/securepulse", "h1", "sp-hero", 375, 812],
   ["/work", "h1", "work-hero", 375, 812],
   ["/work", "dl", "work-figures", 375, 812],
   ["/", "footer", "footer", 390, 844],

--- a/qa-mobile/desktop.mjs
+++ b/qa-mobile/desktop.mjs
@@ -12,7 +12,7 @@ const BASE = process.env.BASE ?? "http://localhost:3100";
 const DIR = path.resolve(import.meta.dirname, process.argv[2] ?? "run", "desktop");
 fs.mkdirSync(DIR, { recursive: true });
 
-const ROUTES = ["/", "/securepuls", "/kai", "/work", "/contact"];
+const ROUTES = ["/", "/securepulse", "/kai", "/work", "/contact"];
 const SIZES = [
   { name: "1440x900", w: 1440, h: 900 },
   { name: "1920x1080", w: 1920, h: 1080 },
@@ -40,8 +40,8 @@ const CROPS = [
   ["/", "#products", "home-products"],
   ["/", "main > section:nth-of-type(2)", "home-thesis"],
   ["/", "main > section:nth-of-type(3)", "home-proof"],
-  ["/securepuls", "main > section:nth-of-type(1)", "sp-hero"],
-  ["/securepuls", 'div[role="img"][aria-label^="A draft finding"]', "sp-evidence"],
+  ["/securepulse", "main > section:nth-of-type(1)", "sp-hero"],
+  ["/securepulse", 'div[role="img"][aria-label^="A draft finding"]', "sp-evidence"],
   ["/kai", "main > section:nth-of-type(1)", "kai-hero"],
   ["/kai", "main > section:nth-of-type(2)", "kai-value"],
   ["/work", "main > section:nth-of-type(1)", "work-hero"],

--- a/qa-mobile/prod-smoke.mjs
+++ b/qa-mobile/prod-smoke.mjs
@@ -9,17 +9,17 @@ import { chromium, webkit } from "@playwright/test";
 const BASE = process.argv[2] ?? "https://www.kaibresystems.com";
 const ROUTES = [
   "/",
-  "/securepuls",
-  "/securepuls/indonesia",
-  "/id/securepuls/indonesia",
+  "/securepulse",
+  "/securepulse/indonesia",
+  "/id/securepulse/indonesia",
   "/kai",
   "/work",
   "/contact",
 ];
 
-/** The SecurePuls Indonesia pair carries its own localised chrome — no
+/** The SecurePulse Indonesia pair carries its own localised chrome — no
  *  hamburger menu, a language toggle instead, and hreflang alternates. */
-const isMicrosite = (route) => route.endsWith("/securepuls/indonesia");
+const isMicrosite = (route) => route.endsWith("/securepulse/indonesia");
 
 const fail = [];
 const bad = (s) => {
@@ -101,7 +101,7 @@ async function run(engineName, browserType, viewport, isMobile) {
         mailto: !!document.querySelector('footer a[href^="mailto:"]'),
         text: (document.body.innerText || "").replace(/\\s+/g, " "),
         images: document.images.length,
-        langToggle: !!document.querySelector('header nav a[href*="securepuls/indonesia"]'),
+        langToggle: !!document.querySelector('header nav a[href*="securepulse/indonesia"]'),
         htmlLang: document.documentElement.lang,
         alternates: [...document.querySelectorAll("link[rel=alternate][hreflang]")]
           .map((l) => l.getAttribute("hreflang") + " " + l.href),
@@ -122,7 +122,7 @@ async function run(engineName, browserType, viewport, isMobile) {
       if (m.htmlLang !== expectedLang)
         bad(`${route}: html lang is "${m.htmlLang}", expected "${expectedLang}"`);
       for (const code of ["en", "id"]) {
-        if (!m.alternates.some((a) => a.startsWith(code + " ") && a.includes("securepuls/indonesia")))
+        if (!m.alternates.some((a) => a.startsWith(code + " ") && a.includes("securepulse/indonesia")))
           bad(`${route}: missing hreflang "${code}" alternate (${JSON.stringify(m.alternates)})`);
       }
     }
@@ -185,7 +185,7 @@ async function run(engineName, browserType, viewport, isMobile) {
   } else {
     const page = await ctx.newPage();
     await page.goto(BASE + "/", { waitUntil: "networkidle" });
-    for (const label of ["SecurePuls", "kAI", "Work"]) {
+    for (const label of ["SecurePulse", "kAI", "Work"]) {
       const link = page.getByRole("navigation", { name: "Main" }).getByRole("link", { name: label, exact: true }).first();
       const href = await link.getAttribute("href");
       const r = await page.request.get(BASE + href);
@@ -220,8 +220,10 @@ async function routing() {
     ["/projects", "/work"],
     ["/team", "/"],
     ["/careers", "/contact"],
-    // The product is spelled SecurePuls; the route was corrected to match.
-    ["/securepulse", "/securepuls"],
+    // The product is spelled SecurePulse; the legacy slugs redirect.
+    ["/securepuls", "/securepulse"],
+    ["/securepuls/indonesia", "/securepulse/indonesia"],
+    ["/id/securepuls/indonesia", "/id/securepulse/indonesia"],
   ]) {
     const r = await fetch(BASE + from, { redirect: "manual" });
     const loc = r.headers.get("location") ?? "";

--- a/qa-mobile/resize.mjs
+++ b/qa-mobile/resize.mjs
@@ -22,7 +22,7 @@ const IOS_UA =
   "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 " +
   "(KHTML, like Gecko) Version/18.5 Mobile/15E148 Safari/604.1";
 
-const ROUTES = ["/", "/securepuls", "/kai", "/work", "/contact"];
+const ROUTES = ["/", "/securepulse", "/kai", "/work", "/contact"];
 
 /** The matrix the brief requires. */
 const CASES = [

--- a/src/app/(site)/layout.tsx
+++ b/src/app/(site)/layout.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import { SiteChrome } from "@/components/layout/site-chrome";
 
 /**
- * Layout for the company site proper. The SecurePuls Indonesia experience
+ * Layout for the company site proper. The SecurePulse Indonesia experience
  * lives outside this group and carries its own, fully localised chrome — an
  * Indonesian-language page must not open under an English header.
  */

--- a/src/app/(site)/securepulse/page.tsx
+++ b/src/app/(site)/securepulse/page.tsx
@@ -13,7 +13,7 @@ import { Callout, WorkflowSteps } from "@/components/modules";
 import {
   AssessmentPanel,
   EvidenceLink,
-  SecurePulsName,
+  SecurePulseName,
   VisualFrame,
 } from "@/components/visuals";
 import {
@@ -26,22 +26,22 @@ import {
   SP_REPORT,
   SP_STATUS,
   SP_WORKFLOW,
-} from "@/content/securepuls";
+} from "@/content/securepulse";
 
 export const metadata: Metadata = {
-  title: "SecurePuls — Physical security assessment",
+  title: "SecurePulse — Physical security assessment",
   description:
-    "SecurePuls turns a physical security inspection into a structured, evidence-backed assessment: a checklist built for the site's emirate and sector, photo evidence captured on the walk, and findings a named assessor signs off.",
-  alternates: { canonical: "/securepuls" },
+    "SecurePulse turns a physical security inspection into a structured, evidence-backed assessment: a checklist built for the site's emirate and sector, photo evidence captured on the walk, and findings a named assessor signs off.",
+  alternates: { canonical: "/securepulse" },
   openGraph: {
-    title: "SecurePuls — Physical security assessment | Kaibre",
+    title: "SecurePulse — Physical security assessment | Kaibre",
     description:
-      "Structured, evidence-backed physical security assessments for UAE and Gulf sites. SecurePuls drafts; qualified people decide.",
-    url: "/securepuls",
+      "Structured, evidence-backed physical security assessments for UAE and Gulf sites. SecurePulse drafts; qualified people decide.",
+    url: "/securepulse",
   },
 };
 
-export default function SecurePulsPage() {
+export default function SecurePulsePage() {
   return (
     <>
       {/* Hero */}
@@ -55,7 +55,7 @@ export default function SecurePulsPage() {
           <div className="grid grid-cols-[minmax(0,1fr)] items-center gap-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)] lg:gap-16">
             <div>
               <p className="text-heading-1 font-medium text-fg">
-                <SecurePulsName animate />
+                <SecurePulseName animate />
                 <span className="ml-3 text-body font-normal text-fg-subtle">
                   {SP_HERO.category}
                 </span>

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -19,8 +19,8 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const TOPICS: Record<string, string> = {
-  securepuls: "SecurePuls",
-  "securepuls-id": "SecurePuls Indonesia",
+  securepulse: "SecurePulse",
+  "securepulse-id": "SecurePulse Indonesia",
   kai: "kAI",
   partnership: "A partnership",
   commissioned: "A commissioned system",
@@ -63,12 +63,12 @@ export async function POST(request: Request) {
   const work = clean(payload.work, 5000);
   const topicKey = clean(payload.topic, 40);
   const topic = TOPICS[topicKey] ?? TOPICS.other;
-  /* Optional fields from the SecurePuls Indonesia form. */
+  /* Optional fields from the SecurePulse Indonesia form. */
   const role = clean(payload.role, 120);
   const orgType = clean(payload.orgType, 60);
   const locale = clean(payload.locale, 8);
 
-  /* 12 rather than 40: the SecurePuls Indonesia form asks for one workflow
+  /* 12 rather than 40: the SecurePulse Indonesia form asks for one workflow
      in a few words ("policy review" must pass). The company form still asks
      for more client-side; this is the floor, not the ask. */
   if (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -85,7 +85,7 @@
   --color-signal-600: oklch(0.512 0.062 218);
 
   /* --- Indonesian flag red. Used only by the market-designation mark in
-     the SecurePuls Indonesia chrome — drawn as CSS bands rather than the
+     the SecurePulse Indonesia chrome — drawn as CSS bands rather than the
      🇮🇩 emoji, because Windows renders flag emoji as the letters "ID". --- */
   --color-merah: oklch(0.55 0.2 27);
 
@@ -508,7 +508,7 @@
   }
 }
 
-/* "Puls" in SecurePuls, breathing. The glow is a suggestion rather than a
+/* "Puls" in SecurePulse, breathing. The glow is a suggestion rather than a
    sign: the triple 40px bloom of the first pass read as neon on an
    enterprise page, so the peak is now one tight halo. */
 @keyframes textBreathe {

--- a/src/app/id/securepulse/indonesia/page.tsx
+++ b/src/app/id/securepulse/indonesia/page.tsx
@@ -22,6 +22,6 @@ export const metadata: Metadata = {
   },
 };
 
-export default function SecurePulsIndonesiaIdPage() {
+export default function SecurePulseIndonesiaIdPage() {
   return <IndonesiaExperience content={ID} />;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -115,7 +115,7 @@ export default function RootLayout({
         />
       </head>
       {/* Chrome lives in the route groups rather than here: the company site
-          renders the English shell via `(site)/layout.tsx`, and the SecurePuls
+          renders the English shell via `(site)/layout.tsx`, and the SecurePulse
           Indonesia experience renders its own localised shell. The root
           `not-found` and `error` pages compose `SiteChrome` themselves. */}
       <body className="min-h-dvh bg-ink-950 antialiased">

--- a/src/app/securepulse/indonesia/page.tsx
+++ b/src/app/securepulse/indonesia/page.tsx
@@ -22,6 +22,6 @@ export const metadata: Metadata = {
   },
 };
 
-export default function SecurePulsIndonesiaPage() {
+export default function SecurePulseIndonesiaPage() {
   return <IndonesiaExperience content={EN} />;
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -16,7 +16,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     languages?: Record<string, string>;
   }[] = [
     { path: "", priority: 1 },
-    { path: "/securepuls", priority: 0.9 },
+    { path: "/securepulse", priority: 0.9 },
     { path: EN_PATH, priority: 0.9, languages: indoLanguages },
     { path: ID_PATH, priority: 0.9, languages: indoLanguages },
     { path: "/work", priority: 0.8 },

--- a/src/components/forms/contact-form.tsx
+++ b/src/components/forms/contact-form.tsx
@@ -19,8 +19,8 @@ import { cn } from "@/lib/utils";
 
 const TOPICS = [
   {
-    value: "securepuls",
-    label: "SecurePuls",
+    value: "securepulse",
+    label: "SecurePulse",
     placeholder:
       "e.g. We assess physical security across a dozen sites in Abu Dhabi and Dubai. Two senior assessors spend about three weeks per site walking it, writing findings, and producing the report — so each site gets covered once a year at best.",
   },

--- a/src/components/indonesia/chrome.tsx
+++ b/src/components/indonesia/chrome.tsx
@@ -3,13 +3,13 @@
 import Link from "next/link";
 import type { MouseEvent } from "react";
 import { KaibreWordmark } from "@/components/brand/wordmark";
-import { SecurePulsName } from "@/components/visuals";
+import { SecurePulseName } from "@/components/visuals";
 import { PATH_BY_LOCALE } from "@/content/indonesia/locale";
 import type { IndoContent } from "@/content/indonesia/types";
 import { cn } from "@/lib/utils";
 
 /**
- * Microsite header for the SecurePuls Indonesia experience.
+ * Microsite header for the SecurePulse Indonesia experience.
  *
  * Deliberately simpler than the company-site header: one page, so there is no
  * menu to manage — the chrome carries the wordmark, the product identity, the
@@ -43,7 +43,7 @@ export function IndoHeader({ content }: { content: IndoContent }) {
         <span className="hidden items-center gap-3 sm:flex">
           <span aria-hidden className="h-6 w-px shrink-0 bg-border-strong" />
           <span className="text-body font-medium leading-none text-fg">
-            <SecurePulsName animate={false} />
+            <SecurePulseName animate={false} />
           </span>
           <span className="flex items-center gap-1.5 leading-none text-small text-fg-subtle">
             <IndonesiaFlag />

--- a/src/components/indonesia/contact-form.tsx
+++ b/src/components/indonesia/contact-form.tsx
@@ -7,12 +7,12 @@ import type { IndoContent } from "@/content/indonesia/types";
 import { cn } from "@/lib/utils";
 
 /**
- * Contact form for the SecurePuls Indonesia experience.
+ * Contact form for the SecurePulse Indonesia experience.
  *
  * Same three-layer delivery as the company-site form — API send, mail-app
  * handoff, plain-text address — with the copy fully driven by the locale
  * dictionary, plus the two fields an enterprise evaluation needs: role and
- * organisation type. Posts the `securepuls-id` topic so the enquiry arrives
+ * organisation type. Posts the `securepulse-id` topic so the enquiry arrives
  * labelled.
  */
 
@@ -46,14 +46,14 @@ function buildMailto(f: Fields, orgTypeLabel: string) {
     `Company: ${f.company}`,
     f.role ? `Role: ${f.role}` : null,
     `Organisation type: ${orgTypeLabel}`,
-    `About: SecurePuls Indonesia`,
+    `About: SecurePulse Indonesia`,
     "",
     f.work,
   ]
     .filter((line): line is string => line !== null)
     .join("\n");
   return `mailto:${SITE.email}?subject=${encodeURIComponent(
-    `SecurePuls Indonesia — ${f.company}`,
+    `SecurePulse Indonesia — ${f.company}`,
   )}&body=${encodeURIComponent(body)}`;
 }
 
@@ -109,7 +109,7 @@ export function IndoContactForm({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           ...fields,
-          topic: "securepuls-id",
+          topic: "securepulse-id",
           locale,
           website,
         }),

--- a/src/components/indonesia/experience.tsx
+++ b/src/components/indonesia/experience.tsx
@@ -15,7 +15,7 @@ import { IndoFooter } from "@/components/indonesia/footer";
 import { IndoContactForm } from "@/components/indonesia/contact-form";
 import { LangSync } from "@/components/indonesia/lang-sync";
 import {
-  AssessmentOverview,
+  DocumentPanel,
   FlowCompare,
   IconList,
   RemediationTable,
@@ -26,7 +26,7 @@ import {
 import type { IndoContent } from "@/content/indonesia/types";
 
 /**
- * The SecurePuls Indonesia experience — one component, two dictionaries.
+ * The SecurePulse Indonesia experience — one component, two dictionaries.
  *
  * Ordered for a two-to-three-minute executive read: outcome and time
  * compression in the headline; inputs and deliverables before any concept;
@@ -66,9 +66,9 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
 
       <main id="main" tabIndex={-1}>
         {/* Hero — outcome, time compression, and what the software is. */}
-        <Section surface="ink" space="flush" className="pb-20 pt-14 sm:pb-24 sm:pt-20">
+        <Section surface="ink" space="flush" className="pb-16 pt-10 sm:pb-24 sm:pt-20">
           <Container>
-            <div className="grid grid-cols-[minmax(0,1fr)] items-center gap-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)] lg:gap-16">
+            <div className="grid grid-cols-[minmax(0,1fr)] items-center gap-9 sm:gap-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)] lg:gap-16">
               <div>
                 <Heading level={1} size="display-1" className="max-w-[26ch]">
                   {c.hero.headline}
@@ -84,9 +84,16 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
                 </div>
               </div>
 
-              <div>
-                <VisualFrame label={c.hero.panel.alt}>
-                  <AssessmentOverview panel={c.hero.panel} />
+              <div className="relative">
+                {/* One quiet atmospheric moment: a warm bed of light behind
+                    the document, so the paper reads as lit rather than pasted
+                    onto the black. Decorative only. */}
+                <span
+                  aria-hidden
+                  className="pointer-events-none absolute -inset-5 rounded-card bg-accent opacity-[0.14] blur-2xl"
+                />
+                <VisualFrame label={c.hero.panel.alt} className="relative">
+                  <DocumentPanel panel={c.hero.panel} />
                 </VisualFrame>
               </div>
             </div>
@@ -97,7 +104,7 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
         <Section surface="ember">
           <Container>
             <SectionHeader heading={c.inOut.heading} />
-            <div className="mt-12 grid grid-cols-[minmax(0,1fr)] gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.15fr)] lg:gap-14">
+            <div className="mt-8 grid grid-cols-[minmax(0,1fr)] gap-8 sm:mt-12 sm:gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.15fr)] lg:gap-14">
               <div>
                 <h3 className="text-heading-2 text-fg">{withBrand(c.inOut.reads.title)}</h3>
                 <IconList items={c.inOut.reads.items} className="mt-6" />
@@ -122,7 +129,7 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
         <Section surface="ink">
           <Container>
             <SectionHeader heading={c.trace.heading} body={c.trace.body} />
-            <div className="mt-12 grid grid-cols-[minmax(0,1fr)] gap-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)] lg:gap-20">
+            <div className="mt-8 grid grid-cols-[minmax(0,1fr)] gap-9 sm:mt-12 sm:gap-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)] lg:gap-20">
               <TraceChain nodes={c.trace.chain} caption={c.trace.caption} />
               <div>
                 <Heading level={3} size="heading-1">
@@ -147,7 +154,7 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
         <Section surface="coal">
           <Container>
             <SectionHeader heading={c.deliverables.heading} />
-            <div className="mt-12 grid grid-cols-[minmax(0,1fr)] items-start gap-10 lg:grid-cols-[minmax(0,1.25fr)_minmax(0,1fr)] lg:gap-14">
+            <div className="mt-8 grid grid-cols-[minmax(0,1fr)] items-start gap-8 sm:mt-12 sm:gap-10 lg:grid-cols-[minmax(0,1.25fr)_minmax(0,1fr)] lg:gap-14">
               <RemediationTable content={c.deliverables.remediation} />
               <ReportPreview content={c.deliverables.report} />
             </div>
@@ -158,11 +165,10 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
         <Section surface="ink">
           <Container>
             <SectionHeader heading={c.comparison.heading} />
-            <div className="mt-12">
+            <div className="mt-8 sm:mt-12">
               <FlowCompare comparison={c.comparison} />
             </div>
-            <Note className="mt-6">{c.comparison.note}</Note>
-            <Callout heading={c.comparison.review.heading} className="mt-12">
+            <Callout heading={c.comparison.review.heading} className="mt-8 p-5 sm:mt-12 sm:p-9">
               {c.comparison.review.body.map((p) => (
                 <Text key={p}>{p}</Text>
               ))}
@@ -174,7 +180,7 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
         <Section surface="coal">
           <Container>
             <SectionHeader heading={c.useCases.heading} />
-            <div className="mt-12 grid grid-cols-[minmax(0,1fr)] gap-10 sm:grid-cols-2 lg:grid-cols-3 lg:gap-8">
+            <div className="mt-8 grid grid-cols-[minmax(0,1fr)] gap-8 sm:mt-12 sm:grid-cols-2 sm:gap-10 lg:grid-cols-3 lg:gap-8">
               {c.useCases.groups.map((group) => (
                 <div key={group.title}>
                   <h3 className="text-heading-2 text-fg">{group.title}</h3>
@@ -199,7 +205,7 @@ export function IndonesiaExperience({ content }: { content: IndoContent }) {
         <Section surface="ink">
           <Container>
             <SectionHeader heading={c.indonesia.heading} />
-            <dl className="mt-12 grid grid-cols-[minmax(0,1fr)] gap-px overflow-hidden rounded-card border border-border bg-border sm:grid-cols-2">
+            <dl className="mt-8 grid grid-cols-[minmax(0,1fr)] gap-px overflow-hidden rounded-card border border-border bg-border sm:mt-12 sm:grid-cols-2">
               {c.indonesia.items.map((item) => (
                 <div key={item.title} className="bg-surface-raised p-6">
                   <dt className="text-body font-medium text-fg">{item.title}</dt>

--- a/src/components/indonesia/footer.tsx
+++ b/src/components/indonesia/footer.tsx
@@ -5,7 +5,7 @@ import { SITE } from "@/content/site";
 import type { IndoContent } from "@/content/indonesia/types";
 
 /**
- * Compact, fully localised footer for the SecurePuls Indonesia experience.
+ * Compact, fully localised footer for the SecurePulse Indonesia experience.
  * One block rather than the company site's column groups: this is a single
  * page, and the footer's jobs are attribution, a route back to Kaibre, the
  * plain-text address (the contact fallback of last resort), and the

--- a/src/components/indonesia/visuals.tsx
+++ b/src/components/indonesia/visuals.tsx
@@ -59,43 +59,68 @@ const TONE_FILL = {
 } as const;
 
 /* ==========================================================================
-   AssessmentOverview — the hero panel
+   DocumentPanel — one page of the actual work product
    --------------------------------------------------------------------------
-   What an assessment looks like at a glance: how many requirements, how they
-   split across compliant / partial / gap, the open findings, and the review
-   state. The figures are illustrative and the panel says so in its corner.
+   The hero visual is a page from a compliance assessment for an obviously
+   fictional Indonesian bank: paper, a document header, and the requirement →
+   evidence → assessment → severity → remediation → reviewer record. It shows
+   what SecurePulse produces rather than a dashboard about it. The corner tag
+   is the only illustrative marker; the accessible label states the fiction
+   outright. Secondary rows drop out below the sm breakpoint so a phone reads
+   five short rows, not seven.
    ========================================================================== */
 
-export function AssessmentOverview({
+export function DocumentPanel({
   panel,
 }: {
   panel: IndoContent["hero"]["panel"];
 }) {
   return (
-    <div className="p-6">
-      <div className="flex items-baseline justify-between gap-4">
-        <p className="text-small text-fg-subtle">{panel.caption}</p>
-        <p className="shrink-0 font-mono text-label uppercase tracking-[0.085em] text-fg-subtle">
+    <div className="bg-cream-50 p-5 text-ink-950 sm:p-6">
+      <div className="flex items-start justify-between gap-4 border-b border-ink-300 pb-3.5">
+        <div className="min-w-0">
+          <p className="font-mono text-label uppercase tracking-[0.085em] text-ink-600">
+            {panel.institution}
+          </p>
+          <p className="mt-1 text-body font-medium">{panel.title}</p>
+        </div>
+        <p className="shrink-0 font-mono text-label uppercase tracking-[0.085em] text-ink-500">
           {panel.tag}
         </p>
       </div>
 
-      {/* One hierarchy level: uniform label → value rows. The dot carries the
-          state; nothing else is annotated. */}
-      <ul className="mt-5">
-        {panel.rows.map((row, i) => (
-          <li
+      <dl>
+        {panel.rows.map((row) => (
+          <div
             key={row.label}
-            className="flex items-baseline justify-between gap-4 border-t border-border py-3 first:border-t-0"
+            className={cn(
+              "grid grid-cols-[minmax(0,6.5rem)_minmax(0,1fr)] gap-x-4 border-b border-ink-200 py-2.5 last:border-b-0 sm:grid-cols-[minmax(0,8rem)_minmax(0,1fr)]",
+              row.secondary && "hidden sm:grid",
+            )}
           >
-            <span className="text-body text-fg-muted">{row.label}</span>
-            <span className="flex shrink-0 items-center gap-2 text-body text-fg">
-              <PulseDot tone={row.tone} delay={i * 320} />
+            <dt className="text-fine text-ink-600">{row.label}</dt>
+            <dd
+              className={cn(
+                "text-fine font-medium",
+                row.tone === "attention"
+                  ? "text-brand-700"
+                  : row.tone === "positive"
+                    ? "text-success-600"
+                    : "text-ink-950",
+              )}
+            >
               {row.value}
-            </span>
-          </li>
+            </dd>
+          </div>
         ))}
-      </ul>
+      </dl>
+
+      {/* The page continues — suggested, never written. */}
+      <div aria-hidden className="mt-4 hidden space-y-1.5 sm:block">
+        <div className="h-1.5 w-full rounded-pill bg-ink-200" />
+        <div className="h-1.5 w-4/5 rounded-pill bg-ink-200" />
+        <div className="h-1.5 w-3/5 rounded-pill bg-ink-200" />
+      </div>
     </div>
   );
 }
@@ -118,11 +143,11 @@ export function IconList({
   className?: string;
 }) {
   return (
-    <ul className={cn("space-y-3.5", className)}>
+    <ul className={cn("space-y-3 sm:space-y-3.5", className)}>
       {items.map((item) => {
         const Icon = ICONS[item.icon];
         return (
-          <li key={item.label} className="flex items-start gap-3.5">
+          <li key={item.label} className="flex items-start gap-3 sm:gap-3.5">
             <span
               aria-hidden
               className={cn(
@@ -163,7 +188,7 @@ export function StageGrid({
   stages: IndoContent["workflow"]["stages"];
 }) {
   return (
-    <ol className="mt-12 grid grid-cols-[minmax(0,1fr)] gap-x-8 gap-y-10 sm:grid-cols-2 lg:grid-cols-4">
+    <ol className="mt-8 grid grid-cols-[minmax(0,1fr)] gap-x-8 gap-y-8 sm:mt-12 sm:grid-cols-2 sm:gap-y-10 lg:grid-cols-4">
       {stages.map((stage) => {
         const Icon = ICONS[stage.icon];
         return (
@@ -218,7 +243,7 @@ export function TraceChain({
                 {!last ? <span className="w-px flex-1 bg-border-strong" /> : null}
               </div>
 
-              <div className={cn(!last && "pb-5")}>
+              <div className={cn(!last && "pb-4 sm:pb-5")}>
                 <p className="text-small text-fg-subtle">{node.label}</p>
                 <p className="mt-1 text-body text-fg">{node.text}</p>
                 {/* Mono reference line. Quiet by default — the accented node
@@ -238,7 +263,7 @@ export function TraceChain({
           );
         })}
       </ol>
-      <figcaption className="mt-5 border-t border-border pt-4 text-fine text-fg-subtle">
+      <figcaption className="mt-4 border-t border-border pt-3.5 text-fine text-fg-subtle">
         {caption}
       </figcaption>
     </figure>
@@ -306,7 +331,7 @@ export function RemediationTable({
           {rows.map((row) => (
             <li
               key={row.finding}
-              className="space-y-1.5 border-b border-border p-5 last:border-b-0"
+              className="space-y-1.5 border-b border-border p-4 last:border-b-0"
             >
               <p className="flex items-baseline justify-between gap-3">
                 <span className="text-small font-medium text-fg">{row.finding}</span>
@@ -328,7 +353,7 @@ export function RemediationTable({
 /* ==========================================================================
    ReportPreview — the deliverable, as a document
    --------------------------------------------------------------------------
-   A table of contents rather than a fake page: the sections a SecurePuls
+   A table of contents rather than a fake page: the sections a SecurePulse
    report carries, in order, ending at the reviewer's sign-off.
    ========================================================================== */
 
@@ -340,8 +365,8 @@ export function ReportPreview({
   return (
     /* The document explains itself: its own title, then its contents. No
        caption underneath repeating what the title already says. */
-    <div className="rounded-card border border-border bg-surface-raised p-6 sm:p-7">
-      <p className="border-b border-border-strong pb-4 text-heading-2 text-fg">
+    <div className="rounded-card border border-border bg-surface-raised p-5 sm:p-7">
+      <p className="border-b border-border-strong pb-3.5 text-heading-2 text-fg sm:pb-4">
         {content.title}
       </p>
       <ol className="mt-4 space-y-2.5">
@@ -369,14 +394,18 @@ export function ReportPreview({
 function FlowColumn({
   flow,
   emphasis,
+  note,
 }: {
   flow: { title: string; steps: readonly string[]; outcome: string };
   emphasis: boolean;
+  /** Rendered under the outcome in fine type — the timing qualification
+   *  travels inside the card instead of occupying its own row. */
+  note?: string;
 }) {
   return (
     <div
       className={cn(
-        "rounded-card border p-6 sm:p-7",
+        "rounded-card border p-5 sm:p-7",
         emphasis ? "border-border-strong bg-surface-raised" : "border-border",
       )}
     >
@@ -397,7 +426,7 @@ function FlowColumn({
                 </span>
                 {!last ? <span className="w-px flex-1 bg-border" /> : null}
               </div>
-              <p className={cn("text-body", last ? "pb-0" : "pb-3.5", emphasis ? "text-fg" : "text-fg-muted")}>
+              <p className={cn("text-body", last ? "pb-0" : "pb-3 sm:pb-3.5", emphasis ? "text-fg" : "text-fg-muted")}>
                 {step}
               </p>
             </li>
@@ -412,6 +441,7 @@ function FlowColumn({
       >
         {flow.outcome}
       </p>
+      {note ? <p className="mt-1.5 text-fine text-fg-subtle">{note}</p> : null}
     </div>
   );
 }
@@ -422,9 +452,9 @@ export function FlowCompare({
   comparison: IndoContent["comparison"];
 }) {
   return (
-    <div className="grid grid-cols-[minmax(0,1fr)] gap-6 sm:grid-cols-2 lg:gap-8">
+    <div className="grid grid-cols-[minmax(0,1fr)] gap-4 sm:grid-cols-2 sm:gap-6 lg:gap-8">
       <FlowColumn flow={comparison.before} emphasis={false} />
-      <FlowColumn flow={comparison.after} emphasis />
+      <FlowColumn flow={comparison.after} emphasis note={comparison.note} />
     </div>
   );
 }

--- a/src/components/layout/site-footer.tsx
+++ b/src/components/layout/site-footer.tsx
@@ -47,7 +47,7 @@ export function SiteFooter() {
                       {/* One span, deliberately: the link is a flex container,
                           and `withBrand` returns several children — as
                           separate flex items the space after the brand name
-                          collapses ("SecurePulsIndonesia"). */}
+                          collapses ("SecurePulseIndonesia"). */}
                       <span>{withBrand(link.label)}</span>
                     </Link>
                   </li>

--- a/src/components/modules/index.tsx
+++ b/src/components/modules/index.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import Link from "next/link";
 import { ArrowUpRight, Check, Minus } from "lucide-react";
 import { Heading, Text } from "@/components/primitives";
-import { SecurePulsName, withBrand } from "@/components/visuals";
+import { SecurePulseName, withBrand } from "@/components/visuals";
 import { cn } from "@/lib/utils";
 
 /* ==========================================================================
@@ -97,7 +97,7 @@ export function ProductCard({
             {/* The product name is the thing being introduced, so it is the
                 largest type here — the tagline supports it, not the reverse. */}
             <h3 className="text-heading-1 font-medium text-fg">
-              {name === "SecurePuls" ? <SecurePulsName animate /> : name}
+              {name === "SecurePulse" ? <SecurePulseName animate /> : name}
             </h3>
             <p className="mt-1 text-small text-fg-subtle">{category}</p>
           </div>

--- a/src/components/visuals/index.tsx
+++ b/src/components/visuals/index.tsx
@@ -204,14 +204,14 @@ export function PulseDot({
 }
 
 /* ==========================================================================
-   SecurePulsName — the product name, with its pulse
+   SecurePulseName — the product name, with its pulse
    --------------------------------------------------------------------------
-   "Puls" carries the accent and breathes. Only the large instances animate;
+   "Pulse" carries the accent and breathes. Only the large instances animate;
    in nav and footer the colour alone does the work, so the chrome stays
    still. The text remains one continuous string for screen readers.
    ========================================================================== */
 
-export function SecurePulsName({
+export function SecurePulseName({
   animate = true,
   delay = 0,
   className,
@@ -231,14 +231,14 @@ export function SecurePulsName({
           animate && "motion-safe:animate-[textBreathe_3.6s_ease-in-out_infinite]",
         )}
       >
-        Puls
+        Pulse
       </span>
     </span>
   );
 }
 
 /**
- * Renders any copy with "SecurePuls" carrying its accent.
+ * Renders any copy with "SecurePulse" carrying its accent.
  *
  * Body mentions take the colour but stay still — a page of breathing words
  * would be unreadable. Only the display instances animate.
@@ -247,9 +247,9 @@ export function SecurePulsName({
  * invisible, so CTA labels keep the plain name.
  */
 export function withBrand(text: string) {
-  if (!text.includes("SecurePuls")) return text;
-  return text.split("SecurePuls").flatMap((part, i) =>
-    i === 0 ? [part] : [<SecurePulsName key={i} delay={i * 420} />, part],
+  if (!text.includes("SecurePulse")) return text;
+  return text.split("SecurePulse").flatMap((part, i) =>
+    i === 0 ? [part] : [<SecurePulseName key={i} delay={i * 420} />, part],
   );
 }
 
@@ -323,7 +323,7 @@ export function Flow({
 }
 
 /* ==========================================================================
-   EvidenceLink — SecurePuls
+   EvidenceLink — SecurePulse
    --------------------------------------------------------------------------
    The product's differentiator in one picture: a finding, and the source it
    is tied back to. Placeholder text only — never real regulation.

--- a/src/content/home.ts
+++ b/src/content/home.ts
@@ -73,11 +73,11 @@ export const PRODUCTS = {
   body: "Two products in market, built on the same discipline. Both keep a person in the decision.",
   items: [
     {
-      name: "SecurePuls",
+      name: "SecurePulse",
       category: "Physical security assessment",
       headline: "Site assessments that show their working.",
-      body: "SecurePuls turns a physical security inspection into a structured assessment: a checklist built for the site's emirate and sector, photo evidence captured on the walk, and findings graded by severity. Every regulatory reference carries an evidence label, and a named assessor signs the report off.",
-      href: "/securepuls",
+      body: "SecurePulse turns a physical security inspection into a structured assessment: a checklist built for the site's emirate and sector, photo evidence captured on the walk, and findings graded by severity. Every regulatory reference carries an evidence label, and a named assessor signs the report off.",
+      href: "/securepulse",
       accent: true,
     },
     {

--- a/src/content/indonesia/en.ts
+++ b/src/content/indonesia/en.ts
@@ -2,7 +2,7 @@ import type { IndoContent } from "./types";
 import { ID_PATH } from "./locale";
 
 /**
- * SecurePuls Indonesia — English.
+ * SecurePulse Indonesia — English.
  *
  * Written to the executive standard: a CCO, GC, CRO or audit executive gives
  * this page two to three minutes. The headline carries the outcome and the
@@ -11,7 +11,7 @@ import { ID_PATH } from "./locale";
  *
  * Claim discipline:
  *  - The ~30-minute figure is founder/practitioner-supplied evidence from the
- *    working SecurePuls workflow, reviewed by a senior regulatory lawyer. It
+ *    working SecurePulse workflow, reviewed by a senior regulatory lawyer. It
  *    is always qualified ("about", "for a configured assessment") and never
  *    an SLA. The qualification line appears with the claim, once per claim
  *    cluster, and stays short.
@@ -19,13 +19,13 @@ import { ID_PATH } from "./locale";
  *    target corpus categories configured per engagement — never as approved,
  *    certified or completely covered.
  *  - Illustrative figures appear only inside mockups tagged "Illustrative".
- *  - "Review-ready", never "audit-ready" — SecurePuls does not confer audit
+ *  - "Review-ready", never "audit-ready" — SecurePulse does not confer audit
  *    assurance.
  */
 export const EN: IndoContent = {
   locale: "en",
   meta: {
-    title: "SecurePuls Indonesia — AI-assisted compliance assessment",
+    title: "SecurePulse Indonesia — AI-assisted compliance assessment",
     description:
       "Gap analysis, severity-ranked findings, a remediation plan and a review-ready draft report in about 30 minutes — grounded in the regulatory corpus configured for the engagement, traced to sources, and verified by your reviewers.",
     ogLocale: "en_GB",
@@ -39,26 +39,28 @@ export const EN: IndoContent = {
   },
   hero: {
     headline: "Compliance assessment drafts in about 30 minutes, not weeks.",
-    body: "SecurePuls AI turns the regulatory requirements, policies and evidence of an Indonesian financial institution into a gap analysis, remediation plan and review-ready draft — verified and signed off by your reviewers. Timing varies with scope, evidence volume and configuration.",
+    body: "SecurePulse AI turns the regulatory requirements, policies and evidence of an Indonesian financial institution into a gap analysis, remediation plan and a polished, review-ready draft — verified and signed off by your reviewers. Timing varies with scope, evidence volume and configuration.",
     cta: { label: "Show us a workflow", href: "#contact" },
     secondary: { label: "How it works", href: "#workflow" },
     panel: {
-      alt: "Illustrative assessment snapshot: requirements assessed, gaps found, severity, remediation state, and review state.",
+      alt: "Illustrative page from a SecurePulse compliance assessment for a fictional Indonesian bank: the requirement, the evidence reviewed, a partial assessment with a high-severity gap, the remediation action, and the reviewer state.",
       tag: "Illustrative",
-      caption: "Assessment",
+      institution: "PT Bank Selat Biru",
+      title: "Regulatory compliance assessment",
       rows: [
-        { label: "Requirements assessed", value: "42", tone: "neutral" },
-        { label: "Gap analysis", value: "5 gaps", tone: "attention" },
-        { label: "High severity", value: "2 findings", tone: "attention" },
-        { label: "Remediation plan", value: "Ready", tone: "positive" },
-        { label: "Reviewer", value: "Pending verification", tone: "neutral" },
+        { label: "Requirement", value: "Access to customer data restricted to authorised roles" },
+        { label: "Evidence reviewed", value: "Access-management policy; review records", secondary: true },
+        { label: "Assessment", value: "Partial — gap identified", tone: "attention" },
+        { label: "Severity", value: "High", tone: "attention" },
+        { label: "Remediation", value: "Periodic access reviews, named ownership" },
+        { label: "Reviewer", value: "Pending verification" },
       ],
     },
   },
   inOut: {
     heading: "What goes in. What comes out.",
     reads: {
-      title: "SecurePuls reads",
+      title: "SecurePulse reads",
       items: [
         {
           icon: "corpus",
@@ -71,7 +73,7 @@ export const EN: IndoContent = {
       ],
     },
     produces: {
-      title: "SecurePuls produces",
+      title: "SecurePulse produces",
       items: [
         { icon: "assessment", label: "Requirement-by-requirement control assessment" },
         { icon: "map", label: "Evidence map with exact source references" },
@@ -95,7 +97,7 @@ export const EN: IndoContent = {
         n: "02",
         icon: "assess",
         title: "Assess",
-        body: "SecurePuls AI maps requirements to evidence and drafts the gap analysis.",
+        body: "SecurePulse AI maps requirements to evidence and drafts the gap analysis.",
       },
       {
         n: "03",
@@ -107,7 +109,7 @@ export const EN: IndoContent = {
         n: "04",
         icon: "review",
         title: "Review & report",
-        body: "Your reviewer verifies the conclusions. SecurePuls produces the report.",
+        body: "Your reviewer verifies the conclusions. SecurePulse produces the report.",
       },
     ],
   },
@@ -139,7 +141,7 @@ export const EN: IndoContent = {
         text: "Pending verification.",
       },
     ],
-    caption: "Illustrative example — not drawn from any specific regulation.",
+    caption: "Illustrative example.",
     labelsHeading: "Every regulatory reference carries its confidence.",
     labels: [
       {
@@ -222,22 +224,22 @@ export const EN: IndoContent = {
       outcome: "Days to weeks",
     },
     after: {
-      title: "With SecurePuls",
+      title: "With SecurePulse",
       steps: [
         "Corpus, policies and evidence in one place",
-        "SecurePuls AI drafts the assessment",
+        "SecurePulse AI drafts the assessment",
         "Gap analysis and remediation plan",
         "Reviewer verification",
-        "Review-ready draft report",
+        "Polished, review-ready draft report",
       ],
-      outcome: "About 30 minutes to a first draft",
+      outcome: "About 30 minutes to a polished draft",
     },
     note: "Timing varies with assessment scope, evidence volume, and configuration.",
     review: {
-      heading: "SecurePuls drafts. Your team decides.",
+      heading: "SecurePulse drafts. Your team decides.",
       body: [
         "AI accelerates the reading, mapping and cross-referencing — and every conclusion stays visible, challengeable, and traceable to its evidence.",
-        "SecurePuls is professional tooling — not a legal opinion, an audit, or a certification. Findings remain drafts until a qualified reviewer verifies them, and every report carries that sign-off.",
+        "SecurePulse is professional tooling — not a legal opinion, an audit, or a certification. Findings remain drafts until a qualified reviewer verifies them, and every report carries that sign-off.",
       ],
     },
   },
@@ -279,7 +281,7 @@ export const EN: IndoContent = {
       },
       {
         title: "Document ingestion for the engagement",
-        note: "SecurePuls can be configured to ingest the applicable corpus alongside your policies, procedures and evidence.",
+        note: "SecurePulse can be configured to ingest the applicable corpus alongside your policies, procedures and evidence.",
       },
       {
         title: "Self-contained deployment",
@@ -290,11 +292,11 @@ export const EN: IndoContent = {
         note: "Analysis runs on a model deployment your institution approves and controls.",
       },
     ],
-    note: "SecurePuls does not claim regulator approval. Corpus coverage is scoped and verified per engagement.",
+    note: "SecurePulse does not claim regulator approval. Corpus coverage is scoped and verified per engagement.",
   },
   contact: {
     heading: "Bring us one compliance workflow.",
-    body: "Show us one assessment your team handles manually — we will demonstrate how SecurePuls structures the evidence, gap analysis, remediation plan and review-ready draft. The initial demonstration costs nothing.",
+    body: "Show us one assessment your team handles manually — we will demonstrate how SecurePulse structures the evidence, gap analysis, remediation plan and review-ready draft. The initial demonstration costs nothing.",
     form: {
       name: { label: "Name", error: "Please add your name." },
       email: {
@@ -325,7 +327,7 @@ export const EN: IndoContent = {
       sending: "Sending…",
       sent: {
         heading: "Thanks — that reached us.",
-        body: "Your message is in our inbox. The people building SecurePuls will come back to you to arrange the demonstration.",
+        body: "Your message is in our inbox. The people building SecurePulse will come back to you to arrange the demonstration.",
       },
       fallback: {
         heading: "One more step.",
@@ -337,10 +339,10 @@ export const EN: IndoContent = {
     },
   },
   footer: {
-    tagline: "SecurePuls is a Kaibre product.",
+    tagline: "SecurePulse is a Kaibre product.",
     links: [
       { label: "Kaibre", href: "/" },
-      { label: "SecurePuls — product overview", href: "/securepuls" },
+      { label: "SecurePulse — product overview", href: "/securepulse" },
       { label: "Contact", href: "#contact" },
     ],
     languageLink: { label: "Baca dalam Bahasa Indonesia", href: ID_PATH },

--- a/src/content/indonesia/id.ts
+++ b/src/content/indonesia/id.ts
@@ -2,7 +2,7 @@ import type { IndoContent } from "./types";
 import { EN_PATH } from "./locale";
 
 /**
- * SecurePuls Indonesia — Bahasa Indonesia.
+ * SecurePulse Indonesia — Bahasa Indonesia.
  *
  * Ditulis langsung dalam ragam formal untuk eksekutif kepatuhan, hukum,
  * risiko dan audit — bukan terjemahan kata per kata, dan tidak lebih panjang
@@ -22,7 +22,7 @@ import { EN_PATH } from "./locale";
 export const ID: IndoContent = {
   locale: "id",
   meta: {
-    title: "SecurePuls Indonesia — asesmen kepatuhan berbantuan AI",
+    title: "SecurePulse Indonesia — asesmen kepatuhan berbantuan AI",
     description:
       "Analisis kesenjangan, temuan berperingkat keparahan, rencana remediasi, dan draf laporan siap telaah dalam sekitar 30 menit — berlandaskan korpus regulasi yang dikonfigurasi untuk penugasan, tertelusur ke sumber, dan diverifikasi penelaah Anda.",
     ogLocale: "id_ID",
@@ -36,26 +36,28 @@ export const ID: IndoContent = {
   },
   hero: {
     headline: "Draf asesmen kepatuhan dalam sekitar 30 menit, bukan berminggu-minggu.",
-    body: "SecurePuls AI mengubah ketentuan regulasi, kebijakan, dan bukti lembaga jasa keuangan Indonesia menjadi analisis kesenjangan, rencana remediasi, dan draf siap telaah — diverifikasi dan disahkan oleh penelaah Anda. Durasi bervariasi menurut cakupan, volume bukti, dan konfigurasi.",
+    body: "SecurePulse AI mengubah ketentuan regulasi, kebijakan, dan bukti lembaga jasa keuangan Indonesia menjadi analisis kesenjangan, rencana remediasi, dan draf rapi yang siap ditelaah — diverifikasi dan disahkan oleh penelaah Anda. Durasi bervariasi menurut cakupan, volume bukti, dan konfigurasi.",
     cta: { label: "Tunjukkan alur kerja Anda", href: "#contact" },
     secondary: { label: "Cara kerjanya", href: "#workflow" },
     panel: {
-      alt: "Cuplikan asesmen ilustratif: ketentuan yang dinilai, kesenjangan yang ditemukan, keparahan, status remediasi, dan status telaah.",
+      alt: "Halaman ilustratif dari asesmen kepatuhan SecurePulse untuk bank Indonesia fiktif: ketentuan, bukti yang ditinjau, asesmen parsial dengan kesenjangan berkeparahan tinggi, tindakan remediasi, dan status penelaah.",
       tag: "Ilustratif",
-      caption: "Asesmen",
+      institution: "PT Bank Selat Biru",
+      title: "Asesmen kepatuhan regulasi",
       rows: [
-        { label: "Ketentuan dinilai", value: "42", tone: "neutral" },
-        { label: "Analisis kesenjangan", value: "5 gap", tone: "attention" },
-        { label: "Keparahan tinggi", value: "2 temuan", tone: "attention" },
-        { label: "Rencana remediasi", value: "Siap", tone: "positive" },
-        { label: "Penelaah", value: "Menunggu verifikasi", tone: "neutral" },
+        { label: "Ketentuan", value: "Akses ke data nasabah dibatasi sesuai peran yang berwenang" },
+        { label: "Bukti ditinjau", value: "Kebijakan manajemen akses; catatan tinjauan", secondary: true },
+        { label: "Asesmen", value: "Parsial — kesenjangan teridentifikasi", tone: "attention" },
+        { label: "Keparahan", value: "Tinggi", tone: "attention" },
+        { label: "Remediasi", value: "Tinjauan akses berkala, penanggung jawab ditunjuk" },
+        { label: "Penelaah", value: "Menunggu verifikasi" },
       ],
     },
   },
   inOut: {
     heading: "Apa yang masuk. Apa yang keluar.",
     reads: {
-      title: "Yang dibaca SecurePuls",
+      title: "Yang dibaca SecurePulse",
       items: [
         {
           icon: "corpus",
@@ -68,7 +70,7 @@ export const ID: IndoContent = {
       ],
     },
     produces: {
-      title: "Yang dihasilkan SecurePuls",
+      title: "Yang dihasilkan SecurePulse",
       items: [
         { icon: "assessment", label: "Asesmen pengendalian ketentuan demi ketentuan" },
         { icon: "map", label: "Peta bukti dengan rujukan sumber yang persis" },
@@ -92,7 +94,7 @@ export const ID: IndoContent = {
         n: "02",
         icon: "assess",
         title: "Asesmen",
-        body: "SecurePuls AI memetakan ketentuan ke bukti dan menyusun analisis kesenjangannya.",
+        body: "SecurePulse AI memetakan ketentuan ke bukti dan menyusun analisis kesenjangannya.",
       },
       {
         n: "03",
@@ -104,7 +106,7 @@ export const ID: IndoContent = {
         n: "04",
         icon: "review",
         title: "Telaah & laporkan",
-        body: "Penelaah Anda memverifikasi kesimpulannya. SecurePuls menghasilkan laporannya.",
+        body: "Penelaah Anda memverifikasi kesimpulannya. SecurePulse menghasilkan laporannya.",
       },
     ],
   },
@@ -136,7 +138,7 @@ export const ID: IndoContent = {
         text: "Menunggu verifikasi.",
       },
     ],
-    caption: "Contoh ilustratif — tidak diambil dari regulasi tertentu.",
+    caption: "Contoh ilustratif.",
     labelsHeading: "Setiap referensi regulasi disertai tingkat keyakinannya.",
     labels: [
       {
@@ -219,22 +221,22 @@ export const ID: IndoContent = {
       outcome: "Berhari-hari hingga berminggu-minggu",
     },
     after: {
-      title: "Dengan SecurePuls",
+      title: "Dengan SecurePulse",
       steps: [
         "Korpus, kebijakan, dan bukti dalam satu tempat",
-        "SecurePuls AI menyusun asesmennya",
+        "SecurePulse AI menyusun asesmennya",
         "Analisis kesenjangan dan rencana remediasi",
         "Verifikasi penelaah",
-        "Draf laporan siap telaah",
+        "Draf laporan rapi yang siap ditelaah",
       ],
-      outcome: "Sekitar 30 menit menuju draf pertama",
+      outcome: "Sekitar 30 menit menuju draf yang rapi",
     },
     note: "Durasi bervariasi menurut cakupan asesmen, volume bukti, dan konfigurasi.",
     review: {
-      heading: "SecurePuls menyusun draf. Tim Anda yang memutuskan.",
+      heading: "SecurePulse menyusun draf. Tim Anda yang memutuskan.",
       body: [
         "AI mempercepat pembacaan, pemetaan, dan referensi silang — dan setiap kesimpulan tetap terlihat, dapat digugat, dan tertelusur ke buktinya.",
-        "SecurePuls adalah perangkat kerja profesional — bukan opini hukum, audit, atau sertifikasi. Temuan tetap berupa draf sampai diverifikasi penelaah yang kompeten, dan setiap laporan memuat pengesahan itu.",
+        "SecurePulse adalah perangkat kerja profesional — bukan opini hukum, audit, atau sertifikasi. Temuan tetap berupa draf sampai diverifikasi penelaah yang kompeten, dan setiap laporan memuat pengesahan itu.",
       ],
     },
   },
@@ -276,7 +278,7 @@ export const ID: IndoContent = {
       },
       {
         title: "Pemuatan dokumen untuk penugasan",
-        note: "SecurePuls dapat dikonfigurasi untuk memuat korpus regulasi yang berlaku beserta kebijakan, prosedur, dan bukti institusi Anda.",
+        note: "SecurePulse dapat dikonfigurasi untuk memuat korpus regulasi yang berlaku beserta kebijakan, prosedur, dan bukti institusi Anda.",
       },
       {
         title: "Deployment mandiri",
@@ -287,11 +289,11 @@ export const ID: IndoContent = {
         note: "Analisis berjalan pada deployment model yang disetujui dan dikendalikan institusi Anda.",
       },
     ],
-    note: "SecurePuls tidak mengklaim persetujuan regulator. Cakupan korpus ditetapkan dan diverifikasi per penugasan.",
+    note: "SecurePulse tidak mengklaim persetujuan regulator. Cakupan korpus ditetapkan dan diverifikasi per penugasan.",
   },
   contact: {
     heading: "Bawakan kami satu alur kerja kepatuhan.",
-    body: "Tunjukkan satu asesmen yang masih dikerjakan tim Anda secara manual — kami akan mendemonstrasikan bagaimana SecurePuls menyusun bukti, analisis kesenjangan, rencana remediasi, dan draf siap telaahnya. Demonstrasi awal tanpa biaya.",
+    body: "Tunjukkan satu asesmen yang masih dikerjakan tim Anda secara manual — kami akan mendemonstrasikan bagaimana SecurePulse menyusun bukti, analisis kesenjangan, rencana remediasi, dan draf siap telaahnya. Demonstrasi awal tanpa biaya.",
     form: {
       name: { label: "Nama", error: "Mohon isi nama Anda." },
       email: {
@@ -323,7 +325,7 @@ export const ID: IndoContent = {
       sending: "Mengirim…",
       sent: {
         heading: "Terima kasih — pesan Anda sudah sampai.",
-        body: "Pesan Anda ada di kotak masuk kami. Tim yang membangun SecurePuls akan menghubungi Anda untuk mengatur demonstrasinya.",
+        body: "Pesan Anda ada di kotak masuk kami. Tim yang membangun SecurePulse akan menghubungi Anda untuk mengatur demonstrasinya.",
       },
       fallback: {
         heading: "Satu langkah lagi.",
@@ -335,10 +337,10 @@ export const ID: IndoContent = {
     },
   },
   footer: {
-    tagline: "SecurePuls adalah produk Kaibre.",
+    tagline: "SecurePulse adalah produk Kaibre.",
     links: [
       { label: "Kaibre", href: "/" },
-      { label: "SecurePuls — ikhtisar produk", href: "/securepuls" },
+      { label: "SecurePulse — ikhtisar produk", href: "/securepulse" },
       { label: "Kontak", href: "#contact" },
     ],
     languageLink: { label: "Read in English", href: EN_PATH },

--- a/src/content/indonesia/locale.ts
+++ b/src/content/indonesia/locale.ts
@@ -1,12 +1,12 @@
 /**
- * The locale pair for the SecurePuls Indonesia experience.
+ * The locale pair for the SecurePulse Indonesia experience.
  *
  * English lives at the natural product path; Bahasa Indonesia under the `/id`
  * prefix, so any future translated page maps predictably under it. These two
  * constants are the single source for routes, hreflang alternates, the
  * sitemap, the header toggle and the tests.
  */
-export const EN_PATH = "/securepuls/indonesia";
-export const ID_PATH = "/id/securepuls/indonesia";
+export const EN_PATH = "/securepulse/indonesia";
+export const ID_PATH = "/id/securepulse/indonesia";
 
 export const PATH_BY_LOCALE = { en: EN_PATH, id: ID_PATH } as const;

--- a/src/content/indonesia/types.ts
+++ b/src/content/indonesia/types.ts
@@ -1,5 +1,5 @@
 /**
- * Content contract for the SecurePuls Indonesia experience.
+ * Content contract for the SecurePulse Indonesia experience.
  *
  * One interface, two dictionaries (`en.ts`, `id.ts`). The type is the
  * synchronisation guarantee: a section, item or label added to one locale
@@ -59,15 +59,19 @@ export interface IndoContent {
     body: string;
     cta: { label: string; href: string };
     secondary: { label: string; href: string };
-    /** Flat assessment snapshot: caption, illustrative tag, uniform rows. */
+    /** The hero visual: one page of a fictional compliance assessment for an
+     *  obviously fictional Indonesian institution. `secondary` rows hide on
+     *  the narrowest screens; the tag is the only illustrative marker. */
     panel: {
       alt: string;
       tag: string;
-      caption: string;
+      institution: string;
+      title: string;
       rows: readonly {
         label: string;
         value: string;
-        tone: "positive" | "attention" | "neutral";
+        tone?: "attention" | "positive";
+        secondary?: boolean;
       }[];
     };
   };

--- a/src/content/kai.ts
+++ b/src/content/kai.ts
@@ -90,7 +90,7 @@ export const KAI_FAQ = {
     },
     {
       q: "Does Kaibre build things other than kAI?",
-      a: "Yes. Kaibre is a software company — kAI is one of its products. We also build SecurePuls, and take on a small number of commissioned production systems each year.",
+      a: "Yes. Kaibre is a software company — kAI is one of its products. We also build SecurePulse, and take on a small number of commissioned production systems each year.",
     },
   ],
 } as const;

--- a/src/content/securepulse.ts
+++ b/src/content/securepulse.ts
@@ -1,11 +1,11 @@
 /**
- * SecurePuls page copy.
+ * SecurePulse page copy.
  *
- * Grounded in the SecurePuls product repositories (read-only inspection).
+ * Grounded in the SecurePulse product repositories (read-only inspection).
  * Every capability below is implemented today. Roadmap items are excluded.
  *
  * Hard constraints:
- *  - SecurePuls assesses PHYSICAL security in the UAE/GCC. Not infosec, not cyber.
+ *  - SecurePulse assesses PHYSICAL security in the UAE/GCC. Not infosec, not cyber.
  *  - No certification, accreditation, regulatory approval, or endorsement is claimed.
  *  - No named customers, institutions, or sectors-as-customers.
  *  - No metrics, percentages, or time savings.
@@ -15,17 +15,17 @@
 export const SP_HERO = {
   category: "Physical security assessment",
   headline: "Site assessments that show their working.",
-  body: "SecurePuls turns a physical security inspection into a structured, evidence-backed assessment. It builds the checklist for the site's emirate and sector, captures photo evidence on the walk, grades findings by severity, and produces a consulting-standard report that a named assessor signs off.",
-  cta: { label: "Talk to us about SecurePuls", href: "/contact?topic=securepuls" },
+  body: "SecurePulse turns a physical security inspection into a structured, evidence-backed assessment. It builds the checklist for the site's emirate and sector, captures photo evidence on the walk, grades findings by severity, and produces a consulting-standard report that a named assessor signs off.",
+  cta: { label: "Talk to us about SecurePulse", href: "/contact?topic=securepulse" },
 } as const;
 
 export const SP_JURISDICTION = {
   heading: "In the UAE, location decides the rulebook.",
   body: [
     "Physical security requirements in the UAE are set per emirate, not federally. A site in Dubai answers to a different authority stack than the same operator's site in Abu Dhabi or Sharjah, and critical infrastructure adds another layer again.",
-    "SecurePuls starts from the site's emirate and sector, and builds the assessment from there. Regulatory references are drawn from a maintained knowledge base rather than generated freely.",
+    "SecurePulse starts from the site's emirate and sector, and builds the assessment from there. Regulatory references are drawn from a maintained knowledge base rather than generated freely.",
   ],
-  note: "SecurePuls currently supports assessments for energy (oil and gas) sites and government buildings.",
+  note: "SecurePulse currently supports assessments for energy (oil and gas) sites and government buildings.",
 } as const;
 
 export const SP_WORKFLOW = {
@@ -39,7 +39,7 @@ export const SP_WORKFLOW = {
     {
       n: "02",
       title: "Generate the checklist",
-      body: "SecurePuls produces an assessment checklist organised across ten physical security domains and tailored to the site rather than pulled from a generic template.",
+      body: "SecurePulse produces an assessment checklist organised across ten physical security domains and tailored to the site rather than pulled from a generic template.",
     },
     {
       n: "03",
@@ -80,7 +80,7 @@ export const SP_EVIDENCE = {
   heading: "Every regulatory claim carries its confidence.",
   body: [
     "UAE physical security guidance is unevenly published. Some requirements are set out in enacted law; some are only visible through approved installers and industry sources; some are genuinely unresolved.",
-    "SecurePuls labels each regulatory reference with the strength of the evidence behind it, and it is not permitted to present an unresolved item as a probable requirement. Where the answer is not established, the assessment says so and escalates it to the competent authority.",
+    "SecurePulse labels each regulatory reference with the strength of the evidence behind it, and it is not permitted to present an unresolved item as a probable requirement. Where the answer is not established, the assessment says so and escalates it to the competent authority.",
   ],
   labels: [
     {
@@ -103,16 +103,16 @@ export const SP_EVIDENCE = {
 } as const;
 
 export const SP_HUMAN = {
-  heading: "SecurePuls drafts. People decide.",
+  heading: "SecurePulse drafts. People decide.",
   body: [
-    "SecurePuls is professional advisory tooling. It is not a regulatory audit, a legal opinion, or a certification, and it does not replace a qualified security assessor.",
+    "SecurePulse is professional advisory tooling. It is not a regulatory audit, a legal opinion, or a certification, and it does not replace a qualified security assessor.",
     "Findings are drafts until a lead assessor and a reviewer accept them. Every report carries a named sign-off, records that it is a point-in-time assessment, and instructs the reader to verify regulatory references with the competent authority.",
   ],
 } as const;
 
 export const SP_REPORT = {
   heading: "A report a consultant would recognise.",
-  body: "SecurePuls produces the sections an assessment report is expected to contain, in a consistent structure, exportable to PDF or Word.",
+  body: "SecurePulse produces the sections an assessment report is expected to contain, in a consistent structure, exportable to PDF or Word.",
   sections: [
     "Assessment summary and risk scorecard",
     "Findings by domain",
@@ -127,12 +127,12 @@ export const SP_REPORT = {
 } as const;
 
 export const SP_INDONESIA = {
-  body: "SecurePuls is also being prepared for Indonesian banks, fintechs, insurers and other regulated financial institutions — with a dedicated experience in English and Bahasa Indonesia.",
-  cta: { label: "SecurePuls for Indonesia", href: "/securepuls/indonesia" },
+  body: "SecurePulse is also being prepared for Indonesian banks, fintechs, insurers and other regulated financial institutions — with a dedicated experience in English and Bahasa Indonesia.",
+  cta: { label: "SecurePulse for Indonesia", href: "/securepulse/indonesia" },
 } as const;
 
 export const SP_STATUS = {
-  heading: "Where SecurePuls is today",
-  body: "SecurePuls is in active development and demonstration with organisations in the UAE and the wider Gulf. If you assess physical security for regulated or high-consequence sites, we would like to show you the current build and hear where it breaks.",
-  cta: { label: "Talk to us about SecurePuls", href: "/contact?topic=securepuls" },
+  heading: "Where SecurePulse is today",
+  body: "SecurePulse is in active development and demonstration with organisations in the UAE and the wider Gulf. If you assess physical security for regulated or high-consequence sites, we would like to show you the current build and hear where it breaks.",
+  cta: { label: "Talk to us about SecurePulse", href: "/contact?topic=securepulse" },
 } as const;

--- a/src/content/site.ts
+++ b/src/content/site.ts
@@ -32,8 +32,8 @@ export const SITE = {
 export const NAV = {
   products: [
     {
-      label: "SecurePuls",
-      href: "/securepuls",
+      label: "SecurePulse",
+      href: "/securepulse",
       note: "Physical security assessment",
     },
     { label: "kAI", href: "/kai", note: "Outbound voice agent" },
@@ -49,8 +49,8 @@ export const FOOTER_GROUPS = [
   {
     title: "Products",
     links: [
-      { label: "SecurePuls", href: "/securepuls" },
-      { label: "SecurePuls Indonesia", href: "/securepuls/indonesia" },
+      { label: "SecurePulse", href: "/securepulse" },
+      { label: "SecurePulse Indonesia", href: "/securepulse/indonesia" },
       { label: "kAI", href: "/kai" },
     ],
   },

--- a/tests/indonesia.spec.ts
+++ b/tests/indonesia.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
 /* ==========================================================================
-   SecurePuls Indonesia — the bilingual pair
+   SecurePulse Indonesia — the bilingual pair
    --------------------------------------------------------------------------
    What only these tests hold:
      - the language toggle works both ways and preserves the visitor's place;
@@ -16,8 +16,8 @@ import { expect, test, type Page } from "@playwright/test";
    covered by the general suites, which include them in their route lists.
    ========================================================================== */
 
-const EN_PATH = "/securepuls/indonesia";
-const ID_PATH = "/id/securepuls/indonesia";
+const EN_PATH = "/securepulse/indonesia";
+const ID_PATH = "/id/securepulse/indonesia";
 
 const EN_H1 = "Compliance assessment drafts in about 30 minutes, not weeks.";
 const ID_H1 =
@@ -29,7 +29,7 @@ const ID_H1 =
  * Indonesian audience uses in English. Stripped before the leak scan.
  */
 const APPROVED_IN_ID = [
-  "SecurePuls",
+  "SecurePulse",
   "Kaibre",
   "Bahasa Indonesia",
   "Read in English", // the language link is deliberately in its own language
@@ -270,7 +270,7 @@ test.describe("regulatory guardrails", () => {
         EN_PATH,
         [
           /about 30 minutes/i,
-          /SecurePuls AI/,
+          /SecurePulse AI/,
           /gap analysis/i,
           /remediation plan/i,
           /severity/i,
@@ -285,7 +285,7 @@ test.describe("regulatory guardrails", () => {
         ID_PATH,
         [
           /sekitar 30 menit/i,
-          /SecurePuls AI/,
+          /SecurePulse AI/,
           /analisis kesenjangan/i,
           /rencana remediasi/i,
           /keparahan/i,
@@ -349,7 +349,7 @@ test.describe("contact form", () => {
 
     expect(posted).not.toBeNull();
     expect(posted!).toMatchObject({
-      topic: "securepuls-id",
+      topic: "securepulse-id",
       locale: "id",
       orgType: "bank",
       role: "Kepala Kepatuhan",
@@ -378,7 +378,7 @@ test.describe("contact form", () => {
 
     await expect(page.locator('[role="status"]')).toBeVisible();
     await expect(page.locator('[role="status"]')).toContainText("Thanks");
-    expect(posted!).toMatchObject({ topic: "securepuls-id", locale: "en", orgType: "insurer" });
+    expect(posted!).toMatchObject({ topic: "securepulse-id", locale: "en", orgType: "insurer" });
   });
 
   test("the header CTA lands on the form, clear of the sticky header", async ({ page }) => {

--- a/tests/mobile.spec.ts
+++ b/tests/mobile.spec.ts
@@ -15,9 +15,9 @@ import { expect, test, type Page } from "@playwright/test";
 
 const ROUTES = [
   "/",
-  "/securepuls",
-  "/securepuls/indonesia",
-  "/id/securepuls/indonesia",
+  "/securepulse",
+  "/securepulse/indonesia",
+  "/id/securepulse/indonesia",
   "/kai",
   "/work",
   "/contact",
@@ -450,8 +450,10 @@ test.describe("navigation", () => {
       ["/projects", "/work"],
       ["/team", "/"],
       ["/careers", "/contact"],
-      // The product is spelled SecurePuls; the old route must not 404.
-      ["/securepulse", "/securepuls"],
+      // The product is spelled SecurePulse; the legacy slugs must not 404.
+      ["/securepuls", "/securepulse"],
+      ["/securepuls/indonesia", "/securepulse/indonesia"],
+      ["/id/securepuls/indonesia", "/id/securepulse/indonesia"],
     ]) {
       await page.goto(from);
       await expect(page).toHaveURL(new RegExp(`${to.replace("/", "\\/")}$`));

--- a/tests/text-resize.spec.ts
+++ b/tests/text-resize.spec.ts
@@ -18,9 +18,9 @@ import { expect, test, type Page } from "@playwright/test";
 
 const ROUTES = [
   "/",
-  "/securepuls",
-  "/securepuls/indonesia",
-  "/id/securepuls/indonesia",
+  "/securepulse",
+  "/securepulse/indonesia",
+  "/id/securepulse/indonesia",
   "/kai",
   "/work",
   "/contact",
@@ -109,7 +109,7 @@ test.describe("text resizing", () => {
             .filter((d) => d.over > 1);
 
           const h1 = document.querySelector("h1");
-          // The SecurePuls Indonesia chrome has no hamburger — its operable
+          // The SecurePulse Indonesia chrome has no hamburger — its operable
           // control is the language toggle link. Measure whichever exists.
           const toggleEl = document.querySelector("header button");
           const langEl = document.querySelector("header nav a");
@@ -139,7 +139,7 @@ test.describe("text resizing", () => {
 
         // Navigation stays visible and operable. The target does not need to
         // grow with the text — it does need to stay at least 44px. On the
-        // SecurePuls Indonesia pages the operable control is the language
+        // SecurePulse Indonesia pages the operable control is the language
         // toggle rather than a hamburger.
         if (m.toggle) {
           expect(m.toggle.w, "hamburger width").toBeGreaterThanOrEqual(44);


### PR DESCRIPTION
Final refinement pass per founder review.

- Official spelling **SecurePulse** everywhere: brand component, copy (EN+ID), metadata, tests. Slugs corrected to /securepulse, /securepulse/indonesia, /id/securepulse/indonesia with 308 redirects covering every legacy /securepuls URL (old reverse redirect retired).
- Hero visual is now the work product: a fictional-bank assessment page (PT Bank Selat Biru) — requirement, evidence, PARTIAL assessment, severity High, remediation, reviewer — with a single ILLUSTRATIVE corner tag and one quiet glow.
- Mobile-first density: tighter stacks below sm, secondary document rows hidden on phones, timing qualifier integrated into the comparison outcome card, shorter illustrative captions.
- "First draft" → "polished draft" / "polished, review-ready draft"; human-review posture unchanged.
- QA: 344 tests green locally (WebKit+Chromium); 30/30 bilingual tests green against the deployed preview via the automation bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)