### PR TITLE
Keep the deployed-preview QA config

### DIFF
--- a/playwright.preview.config.ts
+++ b/playwright.preview.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Deployed-preview QA. Same two engines as the main config, pointed at a
+ * protected Vercel preview via the automation-bypass header. Untracked,
+ * invoked explicitly:
+ *
+ *   E2E_BASE_URL=<preview> VERCEL_AUTOMATION_BYPASS=<secret> \
+ *     npx playwright test tests/indonesia.spec.ts --config playwright.preview.config.ts
+ */
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: true,
+  workers: 4,
+  reporter: [["list"]],
+  use: {
+    baseURL: process.env.E2E_BASE_URL,
+    extraHTTPHeaders: {
+      "x-vercel-protection-bypass": process.env.VERCEL_AUTOMATION_BYPASS ?? "",
+    },
+  },
+  projects: [
+    { name: "mobile-safari", use: { ...devices["iPhone 14 Pro"], browserName: "webkit" } },
+    { name: "mobile-chrome", use: { ...devices["Pixel 7"], browserName: "chromium" } },
+  ],
+});


### PR DESCRIPTION
QA infrastructure only — the two-engine Playwright config that runs the suite against an SSO-protected Vercel preview using the automation-bypass header. No site changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)