### PR TITLE
Whole-site visual authorship and SecurePulse work-product campaign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ qa-screenshots/
 qa-mobile/*/
 playwright-report/
 test-results/
+
+# Playwright MCP session artifacts.
+.playwright-mcp/

--- a/src/app/(site)/kai/page.tsx
+++ b/src/app/(site)/kai/page.tsx
@@ -8,8 +8,15 @@ import {
 } from "@/components/primitives";
 import { Button } from "@/components/primitives/button";
 import { WorkflowSteps } from "@/components/modules";
-import { CallOutcomeList, Flow, VisualFrame } from "@/components/visuals";
-import { KAI_FAQ, KAI_HERO, KAI_VALUE, KAI_WORKFLOW } from "@/content/kai";
+import { Flow, VisualFrame } from "@/components/visuals";
+import { CallPanel } from "@/components/visuals/call";
+import {
+  KAI_CALL_PANEL,
+  KAI_FAQ,
+  KAI_HERO,
+  KAI_VALUE,
+  KAI_WORKFLOW,
+} from "@/content/kai";
 import { CALENDLY_URL } from "@/content/site";
 
 export const metadata: Metadata = {
@@ -62,10 +69,12 @@ export default function KaiPage() {
             </div>
 
             <div>
-              <VisualFrame label="Call outcomes, each tagged with a qualification classification.">
-                <CallOutcomeList />
+              <VisualFrame label={KAI_CALL_PANEL.alt}>
+                <CallPanel content={KAI_CALL_PANEL} />
               </VisualFrame>
-<p className="mt-3 text-fine text-fg-subtle">Interface illustration.</p>
+              <p className="mt-3 text-fine text-fg-subtle">
+                Interface illustration.
+              </p>
             </div>
           </div>
         </Container>
@@ -90,8 +99,8 @@ export default function KaiPage() {
         </Container>
       </Section>
 
-      {/* Workflow */}
-      <Section surface="ink">
+      {/* Workflow (coal) — a change of register between the two ink slabs. */}
+      <Section surface="coal">
         <Container>
           <>
             <SectionHeader
@@ -103,7 +112,7 @@ export default function KaiPage() {
       </Section>
 
       {/* FAQ */}
-      <Section surface="ink" className="border-t border-border">
+      <Section surface="ink">
         <Container size="prose">
           <Heading level={2} size="display-2" className="mt-4">
             {KAI_FAQ.heading}

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -15,13 +15,16 @@ import {
   ProductCard,
 } from "@/components/modules";
 import {
-  AssessmentPanel,
-  CallOutcomeList,
   Flow,
+  IndonesiaFlag,
   PulseDot,
   MonitoredSignal,
   VisualFrame,
 } from "@/components/visuals";
+import { CallPanel } from "@/components/visuals/call";
+import { FindingDocument } from "@/components/visuals/document";
+import { KAI_CALL_PANEL } from "@/content/kai";
+import { SP_HERO_PANEL } from "@/content/securepulse";
 import {
   COMMISSIONED,
   COMPANY,
@@ -138,8 +141,13 @@ export default function HomePage() {
         </Container>
       </Section>
 
-      {/* 4 — Products ------------------------------------------------------ */}
-      <Section surface="ink" id="products" className="relative overflow-hidden">
+      {/* 4 — Products (coal) ----------------------------------------------
+          The products get their own room: warm charcoal rather than a third
+          ink slab, and each panel carries its product's own material — a
+          page of the SecurePulse report, a kAI call mid-conversation. A
+          visitor should be able to tell the two apart with the labels
+          covered. */}
+      <Section surface="coal" id="products" className="relative overflow-hidden">
         <Container className="relative">
           <>
             <SectionHeader
@@ -157,27 +165,42 @@ export default function HomePage() {
               className="pointer-events-none absolute bottom-[-4rem] left-1/2 h-[34rem] w-[70rem] max-w-[130%] -translate-x-1/2 rounded-[50%] bg-[radial-gradient(closest-side,var(--color-brand-500),transparent)] blur-2xl motion-safe:animate-[glowSection_7s_ease-in-out_infinite]"
             />
             <div className="relative grid gap-6 lg:grid-cols-5">
-            <div className="lg:col-span-3">
-              <ProductCard
-                {...PRODUCTS.items[0]}
-                visual={
-                  <VisualFrame label="Draft assessment findings, each carrying the confidence behind it, awaiting sign-off.">
-                    <AssessmentPanel />
-                  </VisualFrame>
-                }
-              />
-            </div>
+              <div className="lg:col-span-3">
+                <ProductCard
+                  {...PRODUCTS.items[0]}
+                  visual={
+                    <VisualFrame label={SP_HERO_PANEL.alt}>
+                      <FindingDocument doc={SP_HERO_PANEL} compact />
+                    </VisualFrame>
+                  }
+                />
+                {/* The Indonesian deployment, one line under its product —
+                    outside the card link, so the two destinations stay two
+                    targets. */}
+                <p className="mt-4 flex flex-wrap items-center gap-x-3 gap-y-1 text-small text-fg-subtle">
+                  <span className="inline-flex items-center gap-2">
+                    <IndonesiaFlag />
+                    <span>{PRODUCTS.securepulseMarket.note}</span>
+                  </span>
+                  <ArrowLink
+                    href={PRODUCTS.securepulseMarket.href}
+                    className="text-small"
+                  >
+                    {PRODUCTS.securepulseMarket.label}
+                  </ArrowLink>
+                </p>
+              </div>
 
-            <div className="lg:col-span-2">
-              <ProductCard
-                {...PRODUCTS.items[1]}
-                visual={
-                  <VisualFrame label="Call outcomes, each tagged with a qualification classification.">
-                    <CallOutcomeList />
-                  </VisualFrame>
-                }
-              />
-            </div>
+              <div className="lg:col-span-2">
+                <ProductCard
+                  {...PRODUCTS.items[1]}
+                  visual={
+                    <VisualFrame label={KAI_CALL_PANEL.alt}>
+                      <CallPanel content={KAI_CALL_PANEL} compact />
+                    </VisualFrame>
+                  }
+                />
+              </div>
             </div>
           </div>
 
@@ -186,8 +209,9 @@ export default function HomePage() {
         </Container>
       </Section>
 
-      {/* 5 — Commissioned systems ------------------------------------------ */}
-      <Section surface="ink" id={COMMISSIONED.id} className="border-t border-border">
+      {/* 5 — Commissioned systems ------------------------------------------
+          The surface change out of coal is the seam; a border would double it. */}
+      <Section surface="ink" id={COMMISSIONED.id}>
         <Container>
           <div className="grid gap-12 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)] lg:gap-20">
             <div>
@@ -260,8 +284,9 @@ export default function HomePage() {
         </Container>
       </Section>
 
-      {/* 8 — Company --------------------------------------------------------- */}
-      <Section surface="ink" id={COMPANY.id}>
+      {/* 8 — Company (coal) — the second charcoal room, so the page steps
+          ink → ember → coal on its way out instead of falling back to black. */}
+      <Section surface="coal" id={COMPANY.id}>
         <Container>
           <div className="grid gap-x-16 gap-y-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)]">
             <SectionHeader heading={COMPANY.heading} body={COMPANY.body} />
@@ -299,7 +324,7 @@ export default function HomePage() {
       </Section>
 
       {/* 9 — Conversion ------------------------------------------------------ */}
-      <Section surface="ink" className="border-t border-border">
+      <Section surface="ink">
         <Container>
           <Callout className="text-center">
             <Heading level={2} size="display-2" className="mx-auto max-w-[18ch]">

--- a/src/app/(site)/securepulse/page.tsx
+++ b/src/app/(site)/securepulse/page.tsx
@@ -11,18 +11,25 @@ import {
 import { ArrowLink, Button } from "@/components/primitives/button";
 import { Callout, WorkflowSteps } from "@/components/modules";
 import {
-  AssessmentPanel,
-  EvidenceLink,
+  IndonesiaFlag,
   SecurePulseName,
   VisualFrame,
 } from "@/components/visuals";
 import {
+  FindingDocument,
+  ReportContents,
+  RequirementMap,
+  RiskScorecard,
+} from "@/components/visuals/document";
+import {
   SP_DOMAINS,
   SP_EVIDENCE,
   SP_HERO,
+  SP_HERO_PANEL,
   SP_HUMAN,
-  SP_INDONESIA,
   SP_JURISDICTION,
+  SP_MAPPING,
+  SP_MARKETS,
   SP_REPORT,
   SP_STATUS,
   SP_WORKFLOW,
@@ -44,14 +51,10 @@ export const metadata: Metadata = {
 export default function SecurePulsePage() {
   return (
     <>
-      {/* Hero */}
-      <Section surface="ink" space="flush" className="pb-20 pt-32 sm:pb-24 sm:pt-40">
+      {/* Hero — the copy beside the work product itself: one page of the
+          report, on paper, lit from behind. */}
+      <Section surface="ink" space="flush" className="pb-20 pt-28 sm:pb-24 sm:pt-36">
         <Container>
-          {/* Centred, not bottom-aligned. The panel is about half the height of
-                the column beside it, so pinning it to the baseline banked the
-                whole difference as one ~320px void in the top right — the
-                largest unexplained empty region on the site. Centring splits it
-                into two margins that read as composition. */}
           <div className="grid grid-cols-[minmax(0,1fr)] items-center gap-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)] lg:gap-16">
             <div>
               <p className="text-heading-1 font-medium text-fg">
@@ -71,17 +74,22 @@ export default function SecurePulsePage() {
               </div>
             </div>
 
-            <div>
-              <VisualFrame label="Draft assessment findings, each carrying the confidence behind it, awaiting sign-off.">
-                <AssessmentPanel />
+            <div className="relative">
+              {/* A warm bed of light behind the document, so the paper reads
+                  as lit rather than pasted onto the black. Decorative only. */}
+              <span
+                aria-hidden
+                className="pointer-events-none absolute -inset-5 rounded-card bg-accent opacity-[0.14] blur-2xl"
+              />
+              <VisualFrame label={SP_HERO_PANEL.alt} className="relative">
+                <FindingDocument doc={SP_HERO_PANEL} />
               </VisualFrame>
-<p className="mt-3 text-fine text-fg-subtle">Interface illustration.</p>
             </div>
           </div>
         </Container>
       </Section>
 
-      {/* Jurisdiction (ember) */}
+      {/* Jurisdiction (ember) — the market fact the product is built on. */}
       <Section surface="ember">
         <Container>
           <>
@@ -94,8 +102,8 @@ export default function SecurePulsePage() {
         </Container>
       </Section>
 
-      {/* Workflow */}
-      <Section surface="ink">
+      {/* Workflow (coal) — a change of register, not another black slab. */}
+      <Section surface="coal">
         <Container>
           <>
             <SectionHeader
@@ -107,7 +115,7 @@ export default function SecurePulsePage() {
       </Section>
 
       {/* Domains */}
-      <Section surface="ink" className="border-t border-border">
+      <Section surface="ink">
         <Container>
           <div className="grid gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)] lg:gap-20">
             <div>
@@ -135,7 +143,8 @@ export default function SecurePulsePage() {
         </Container>
       </Section>
 
-      {/* Evidence discipline (ember) — the product's core differentiator */}
+      {/* Evidence discipline (ember) — the differentiator, shown in the
+          report's own compliance-mapping grammar rather than asserted. */}
       <Section surface="ember">
         <Container>
           <>
@@ -145,7 +154,7 @@ export default function SecurePulsePage() {
             />
           </>
 
-          <EvidenceLink className="mt-12" />
+          <RequirementMap content={SP_MAPPING} className="mt-12" />
 
           <>
             <dl className="mt-10 grid gap-px overflow-hidden rounded-card border border-border bg-border sm:grid-cols-2">
@@ -162,55 +171,73 @@ export default function SecurePulsePage() {
         </Container>
       </Section>
 
-      {/* Human review — above the CTA, by design */}
-      <Section surface="ink">
+      {/* The deliverable (paper) — what leadership actually receives, on the
+          desk it will land on. */}
+      <Section surface="paper">
         <Container>
-          <div className="grid gap-10 lg:grid-cols-2 lg:gap-16">
-            <div>
-              <Callout heading={SP_HUMAN.heading}>
-                {SP_HUMAN.body.map((p) => (
-                  <Text key={p}>{p}</Text>
-                ))}
-              </Callout>
-            </div>
-
-            <div>
-              <Heading level={2} size="heading-1" className="mt-4">
-                {SP_REPORT.heading}
-              </Heading>
-              <Text className="mt-4">{SP_REPORT.body}</Text>
-              <ul className="mt-6 space-y-2.5">
-                {SP_REPORT.sections.map((s) => (
-                  <li key={s} className="flex gap-3 text-body text-fg-muted">
-                    <span aria-hidden className="mt-2.5 size-1 shrink-0 rounded-full bg-accent" />
-                    {s}
-                  </li>
-                ))}
-              </ul>
-            </div>
+          <SectionHeader heading={SP_REPORT.heading} body={SP_REPORT.body} />
+          <div className="mt-8 grid grid-cols-[minmax(0,1fr)] items-start gap-8 sm:mt-12 sm:gap-10 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,1fr)] lg:gap-14">
+            <ReportContents
+              title={SP_REPORT.contents.title}
+              sections={SP_REPORT.contents.sections}
+              signoff={SP_REPORT.contents.signoff}
+            />
+            <RiskScorecard
+              title={SP_REPORT.scorecard.title}
+              tag={SP_REPORT.scorecard.tag}
+              columns={SP_REPORT.scorecard.columns}
+              rows={SP_REPORT.scorecard.rows}
+              totals={SP_REPORT.scorecard.totals}
+            />
           </div>
         </Container>
       </Section>
 
-      {/* Status + CTA */}
+      {/* Human review — above the CTA, by design. */}
+      <Section surface="ink">
+        <Container>
+          <div className="max-w-[46rem]">
+            <Callout heading={SP_HUMAN.heading}>
+              {SP_HUMAN.body.map((p) => (
+                <Text key={p}>{p}</Text>
+              ))}
+            </Callout>
+          </div>
+        </Container>
+      </Section>
+
+      {/* Markets + status + CTA */}
       <Section surface="ink" className="border-t border-border">
-        <Container size="prose">
-          <Heading level={2} size="heading-1">
-            {SP_STATUS.heading}
+        <Container>
+          <Heading level={2} size="display-2">
+            {SP_MARKETS.heading}
           </Heading>
-          <Prose paragraphs={[SP_STATUS.body]} size="body" className="mt-5" />
-          <div className="mt-8">
-            <Button href={SP_STATUS.cta.href}>{SP_STATUS.cta.label}</Button>
+          <div className="mt-10 grid gap-px overflow-hidden rounded-card border border-border bg-border sm:grid-cols-2">
+            {SP_MARKETS.markets.map((market) => (
+              <div key={market.name} className="bg-surface-raised p-6 sm:p-7">
+                <h3 className="flex items-center gap-2.5 text-heading-2 font-medium text-fg">
+                  {"flag" in market && market.flag ? <IndonesiaFlag /> : null}
+                  {market.name}
+                </h3>
+                <p className="mt-1 text-small text-fg-subtle">{market.domain}</p>
+                <p className="mt-3 text-small text-fg-muted">{market.note}</p>
+                {"href" in market && market.href ? (
+                  <ArrowLink href={market.href} className="mt-4">
+                    {market.cta}
+                  </ArrowLink>
+                ) : null}
+              </div>
+            ))}
           </div>
 
-          {/* The Indonesian-market experience, cross-linked rather than folded
-              in: this page carries the UAE physical-security positioning, and
-              the two must not blur into one claim. */}
-          <div className="mt-14 border-t border-border pt-8">
-            <Text size="small">{SP_INDONESIA.body}</Text>
-            <ArrowLink href={SP_INDONESIA.cta.href} className="mt-3">
-              {SP_INDONESIA.cta.label}
-            </ArrowLink>
+          <div className="mt-16 max-w-prose border-t border-border pt-10">
+            <Heading level={2} size="heading-1">
+              {SP_STATUS.heading}
+            </Heading>
+            <Prose paragraphs={[SP_STATUS.body]} size="body" className="mt-5" />
+            <div className="mt-8">
+              <Button href={SP_STATUS.cta.href}>{SP_STATUS.cta.label}</Button>
+            </div>
           </div>
         </Container>
       </Section>

--- a/src/app/(site)/work/page.tsx
+++ b/src/app/(site)/work/page.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from "@/components/primitives/button";
 import { FitList } from "@/components/modules";
 import { Flow, PulseDot } from "@/components/visuals";
+import { SystemTopology } from "@/components/visuals/topology";
 import { WORK_COMMISSIONED, WORK_HERO, WORK_LUXURY } from "@/content/work";
 
 export const metadata: Metadata = {
@@ -63,8 +64,11 @@ export default function WorkPage() {
         </Container>
       </Section>
 
-      {/* Scope */}
-      <Section surface="ink">
+      {/* Scope (coal) — the system's shape, then how a trade moves through
+          it. The topology carries the "production system" argument the
+          figures above cannot: several coordinated subsystems, a gate in
+          front of trading, and an operator seat under all of it. */}
+      <Section surface="coal">
         <Container>
           <>
             <Heading level={2} size="display-2" className="max-w-[20ch]">
@@ -75,28 +79,19 @@ export default function WorkPage() {
             </Text>
           </>
 
-          <div className="mt-12">
+          <SystemTopology content={WORK_LUXURY.topology} className="mt-12" />
+
+          <div className="mt-14 border-t border-border pt-10">
             <h3 className="text-heading-2 font-medium text-fg">
               {WORK_LUXURY.lifecycleTitle}
             </h3>
             <Flow className="mt-7" stages={WORK_LUXURY.lifecycle} />
           </div>
-
-          <ul className="mt-14 grid gap-x-12 border-t border-border pt-10 sm:grid-cols-2 lg:grid-cols-3">
-            {WORK_LUXURY.scope.map((item) => (
-              <li
-                key={item.title}
-                className="border-b border-border py-3.5 text-body text-fg-muted"
-              >
-                {item.title}
-              </li>
-            ))}
-          </ul>
         </Container>
       </Section>
 
       {/* Why it mattered */}
-      <Section surface="ink" className="border-t border-border">
+      <Section surface="ink">
         <Container size="prose">
           <>
             <Heading level={2} size="heading-1">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -188,13 +188,16 @@
   --border-strong: var(--color-ink-700);
   --accent: var(--color-brand-500);
   --accent-hover: var(--color-brand-400);
-  /* Solid fills sit far below accent text so white type clears 4.5:1 with
-     room to spare. The founders pushed this twice: brand-700 read as
-     consumer-SaaS orange, brand-800 was still "not sufficiently burnt", so
-     filled actions now sit on brand-900 — an oxide tone — with brand-800 as
-     the hover lift. White on brand-900 is ~13:1. */
-  --accent-solid: var(--color-brand-900);
-  --accent-solid-hover: var(--color-brand-800);
+  /* Two oranges, two jobs. The oxide tones (brand-800/900, the ember ramp)
+     are the brand *environment* — large surfaces, atmosphere. A primary
+     action is the one place the orange is allowed to be energetic again:
+     when every filled action sat on oxide it was the darkest object on an
+     ink page, and the conversion path read as recessed chrome. brand-600 is
+     the ramp's anchor; white on it is ~4.6:1, so AA holds at body size, and
+     the hover steps *down* the ramp so the pressed state deepens rather
+     than brightens toward the failing contrast of brand-500. */
+  --accent-solid: var(--color-brand-600);
+  --accent-solid-hover: var(--color-brand-700);
   --accent-contrast: oklch(1 0 0);
   --accent-quiet: var(--color-brand-300);
   --focus: var(--color-brand-400);
@@ -242,8 +245,9 @@
  * work product appears — a document should sit on a desk, not float in a
  * void. It exists because the founders asked for document-derived light
  * surfaces; it is not the old alternating white sheet. Type inverts to the
- * ink ramp; the accent holds AA by dropping to brand-700 for marks and
- * brand-800 for fills.
+ * ink ramp; accent marks hold AA by dropping to brand-700, while filled
+ * actions carry the same energetic brand-600 as the dark surfaces — the
+ * primary action is the one saturated object on the sheet.
  */
 [data-surface="paper"] {
   --surface: var(--color-cream-200);
@@ -256,8 +260,8 @@
   --border-strong: var(--color-ink-400);
   --accent: var(--color-brand-700);
   --accent-hover: var(--color-brand-800);
-  --accent-solid: var(--color-brand-800);
-  --accent-solid-hover: var(--color-brand-900);
+  --accent-solid: var(--color-brand-600);
+  --accent-solid-hover: var(--color-brand-700);
   --accent-contrast: oklch(1 0 0);
   --accent-quiet: var(--color-brand-700);
   --focus: var(--color-brand-600);

--- a/src/components/indonesia/chrome.tsx
+++ b/src/components/indonesia/chrome.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import type { MouseEvent } from "react";
 import { KaibreWordmark } from "@/components/brand/wordmark";
-import { SecurePulseName } from "@/components/visuals";
+import { IndonesiaFlag, SecurePulseName } from "@/components/visuals";
 import { PATH_BY_LOCALE } from "@/content/indonesia/locale";
 import type { IndoContent } from "@/content/indonesia/types";
 import { cn } from "@/lib/utils";
@@ -68,23 +68,6 @@ export function IndoHeader({ content }: { content: IndoContent }) {
         </div>
       </div>
     </header>
-  );
-}
-
-/**
- * The Indonesian flag as two CSS bands — deterministic on every platform,
- * unlike the flag emoji, which Windows renders as the letters "ID". Sized to
- * the small-text cap height so it sits on the market label's own line.
- */
-function IndonesiaFlag() {
-  return (
-    <span
-      aria-hidden
-      className="inline-flex h-3 w-[18px] shrink-0 flex-col overflow-hidden rounded-[2px] border border-border-strong"
-    >
-      <span className="h-1/2 bg-merah" />
-      <span className="h-1/2 bg-white" />
-    </span>
   );
 }
 

--- a/src/components/indonesia/visuals.tsx
+++ b/src/components/indonesia/visuals.tsx
@@ -21,6 +21,7 @@ import type {
   IndoIcon,
 } from "@/content/indonesia/types";
 import { PulseDot } from "@/components/visuals";
+import { FindingDocument, ReportContents } from "@/components/visuals/document";
 
 /* ==========================================================================
    Compliance-specific visual vocabulary
@@ -69,70 +70,7 @@ export function DocumentPanel({
 }: {
   panel: IndoContent["hero"]["panel"];
 }) {
-  return (
-    <div className="bg-cream-50 p-5 text-ink-950 sm:p-6">
-      {/* Document header, in the report's own voice: institution, title, and
-          the version/standing line — with the illustrative tag where a
-          classification would sit. */}
-      <div className="flex items-start justify-between gap-4 border-b-2 border-ink-950/80 pb-3">
-        <div className="min-w-0">
-          <p className="font-mono text-label uppercase tracking-[0.085em] text-ink-600">
-            {panel.institution}
-          </p>
-          <p className="mt-1 font-display text-body font-bold">{panel.title}</p>
-          <p className="mt-0.5 hidden font-mono text-label text-ink-500 sm:block">
-            {panel.docMeta}
-          </p>
-        </div>
-        <p className="shrink-0 font-mono text-label uppercase tracking-[0.085em] text-ink-500">
-          {panel.tag}
-        </p>
-      </div>
-
-      {/* The finding, exactly as the report frames one: id, severity, a
-          title that exercises judgment, and its category/points line. */}
-      <div className="border-b border-ink-200 py-3">
-        <p className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
-          <span className="font-mono text-label tracking-[0.085em] text-ink-600">
-            {panel.finding.id}
-          </span>
-          <span aria-hidden className="size-1.5 rounded-full bg-brand-700" />
-          <span className="font-mono text-label uppercase tracking-[0.085em] text-brand-700">
-            {panel.finding.severity}
-          </span>
-          <span className="hidden font-mono text-label text-ink-500 sm:inline">
-            {panel.finding.meta}
-          </span>
-        </p>
-        <p className="mt-1.5 font-display text-small font-bold leading-snug">
-          {panel.finding.title}
-        </p>
-      </div>
-
-      {/* Run-in body paragraphs — the report's registers, verbatim in style:
-          "What we observed: …", "Remediation: Immediate — …". */}
-      <div className="space-y-2.5 pt-3">
-        {panel.body.map((item) => (
-          <p
-            key={item.label}
-            className={cn(
-              "text-fine leading-relaxed text-ink-700",
-              item.secondary && "hidden sm:block",
-            )}
-          >
-            <strong className="font-medium text-ink-950">{item.label}: </strong>
-            {item.text}
-          </p>
-        ))}
-      </div>
-
-      {/* The document's own footer: section and page position. */}
-      <p className="mt-4 flex items-center justify-between border-t border-ink-200 pt-2.5 font-mono text-label text-ink-500">
-        <span className="hidden sm:inline">SecurePulse</span>
-        <span>{panel.pageLine}</span>
-      </p>
-    </div>
-  );
+  return <FindingDocument doc={panel} />;
 }
 
 /* ==========================================================================
@@ -366,25 +304,15 @@ export function ReportPreview({
 }: {
   content: IndoContent["deliverables"]["report"];
 }) {
+  /* The document explains itself: its own title, its contents, and — because
+     this report's last page is an attestation — the sign-off rows that put
+     "your team decides" inside the deliverable rather than beside it. */
   return (
-    /* The document explains itself: its own title, then its contents. No
-       caption underneath repeating what the title already says. */
-    <div className="rounded-card border border-border bg-surface-raised p-5 shadow-[var(--shadow-card)] sm:p-7">
-      <p className="border-b border-border-strong pb-3.5 text-heading-2 text-fg sm:pb-4">
-        {content.title}
-      </p>
-      <ol className="mt-4 space-y-2.5">
-        {content.sections.map((section, i) => (
-          <li key={section} className="flex items-baseline gap-3">
-            <span className="font-mono text-label text-fg-subtle">
-              {String(i + 1).padStart(2, "0")}
-            </span>
-            <span className="text-body text-fg-muted">{section}</span>
-            <span aria-hidden className="mb-1 flex-1 self-end border-b border-dotted border-border" />
-          </li>
-        ))}
-      </ol>
-    </div>
+    <ReportContents
+      title={content.title}
+      sections={content.sections}
+      signoff={content.signoff}
+    />
   );
 }
 

--- a/src/components/visuals/call.tsx
+++ b/src/components/visuals/call.tsx
@@ -1,0 +1,103 @@
+import { cn } from "@/lib/utils";
+import { PulseDot } from "@/components/visuals";
+
+/* ==========================================================================
+   Call artifacts — kAI's work product is a conversation
+   --------------------------------------------------------------------------
+   SecurePulse ships a document, so its pages carry paper. kAI's output is a
+   qualified conversation, so its visual is the call itself: who said what,
+   the structured answers pulled out of the speech, and the classification
+   that decides whether a person picks it up. No waveforms, no audio bars —
+   the transcript and its extraction ARE the product.
+   ========================================================================== */
+
+export interface CallPanelContent {
+  /** "Outbound call · your number" — where the call runs. */
+  context: string;
+  /** Live state: "In conversation · 02:41". */
+  state: string;
+  /** Speaker-tagged transcript rows. `secondary` rows fold away on phones
+   *  and in the compact variant. */
+  transcript: readonly {
+    speaker: string;
+    /** kAI's own turns are marked so the agent's voice reads apart. */
+    agent?: boolean;
+    text: string;
+    secondary?: boolean;
+  }[];
+  /** The structured answers extracted from the speech. */
+  answersLabel: string;
+  answers: readonly { field: string; value: string }[];
+  /** The classification the call ends in — the handover decision. */
+  outcome: string;
+}
+
+export function CallPanel({
+  content,
+  compact = false,
+}: {
+  content: CallPanelContent;
+  /** Product-card variant: primary transcript rows only, tighter padding. */
+  compact?: boolean;
+}) {
+  return (
+    <div className={cn("p-5", !compact && "sm:p-6")}>
+      {/* Call header: where it runs, and that it is running. */}
+      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 border-b border-border pb-3">
+        <p className="text-small text-fg-subtle">{content.context}</p>
+        <p className="flex items-center gap-2 font-mono text-label text-fg-muted">
+          <PulseDot tone="live" />
+          {content.state}
+        </p>
+      </div>
+
+      {/* The conversation. A mono speaker gutter keeps the two voices
+          scannable; kAI's turns carry the accent so the agent reads apart
+          from the lead without a cartoon chat-bubble in sight. */}
+      <ul className={cn("space-y-2.5 pt-3.5", !compact && "sm:space-y-3")}>
+        {content.transcript.map((row) => (
+          <li
+            key={row.text}
+            className={cn(
+              "grid grid-cols-[2.75rem_minmax(0,1fr)] gap-x-3",
+              row.secondary && (compact ? "hidden" : "hidden sm:grid"),
+            )}
+          >
+            <span
+              className={cn(
+                "pt-0.5 font-mono text-label tracking-[0.085em]",
+                row.agent ? "text-accent" : "text-fg-subtle",
+              )}
+            >
+              {row.speaker}
+            </span>
+            <span className={cn("text-small", row.agent ? "text-fg-muted" : "text-fg")}>
+              {row.text}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      {/* What the speech became: structured answers, not a recording. */}
+      <div className="mt-4 border-t border-border pt-3.5">
+        <p className="font-mono text-label uppercase tracking-[0.085em] text-fg-subtle">
+          {content.answersLabel}
+        </p>
+        <dl className="mt-2.5 flex flex-wrap gap-x-6 gap-y-1.5">
+          {content.answers.map((a) => (
+            <div key={a.field} className="flex items-baseline gap-2">
+              <dt className="text-fine text-fg-subtle">{a.field}</dt>
+              <dd className="text-small text-fg">{a.value}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+
+      {/* The decision the call ends in. */}
+      <p className="mt-4 flex items-center gap-2.5 border-t border-border pt-3.5 text-small font-medium text-fg">
+        <PulseDot tone="positive" size="md" halo />
+        {content.outcome}
+      </p>
+    </div>
+  );
+}

--- a/src/components/visuals/document.tsx
+++ b/src/components/visuals/document.tsx
@@ -1,0 +1,341 @@
+import { cn } from "@/lib/utils";
+
+/* ==========================================================================
+   Document artifacts — the SecurePulse work product, on paper
+   --------------------------------------------------------------------------
+   Everything here is an excerpt of the report the product actually produces,
+   structured after the real deliverable: a severity-headed detailed finding,
+   a table of contents, a severity scorecard, a sign-off block. They are the
+   product's own grammar, so they carry the argument a generic interface
+   panel cannot: this is what your team receives.
+
+   All content arrives as props — the components never invent copy, and any
+   panel carrying figures is tagged "Illustrative" by its content.
+   ========================================================================== */
+
+export interface FindingDocumentContent {
+  /** The one illustrative marker, set where a classification would sit. */
+  tag: string;
+  institution: string;
+  title: string;
+  /** Version and standing line, in the report's voice. */
+  docMeta: string;
+  finding: {
+    id: string;
+    severity: string;
+    title: string;
+    /** Category · points line, in the report's own scoring vocabulary. */
+    meta: string;
+  };
+  /** Run-in paragraphs, exactly as the report writes a finding:
+   *  "What we observed: …". `secondary` items fold away on phones. */
+  body: readonly { label: string; text: string; secondary?: boolean }[];
+  /** The document's own footer — section name and page position. */
+  pageLine: string;
+}
+
+/**
+ * One page of the actual work product: paper, a document header, and a
+ * detailed finding in the report's own anatomy. Rendered inside a
+ * `VisualFrame`, which carries the accessible description.
+ *
+ * `compact` is the product-card excerpt: header, the severity-headed
+ * finding, and the reviewer state — the material without the prose, so the
+ * card stays a teaser and the product page keeps the full page to itself.
+ */
+export function FindingDocument({
+  doc,
+  compact = false,
+}: {
+  doc: FindingDocumentContent;
+  compact?: boolean;
+}) {
+  const rows = compact ? doc.body.slice(-1) : doc.body;
+  return (
+    <div className="bg-cream-50 p-5 text-ink-950 sm:p-6">
+      <div className="flex items-start justify-between gap-4 border-b-2 border-ink-950/80 pb-3">
+        <div className="min-w-0">
+          <p className="font-mono text-label uppercase tracking-[0.085em] text-ink-600">
+            {doc.institution}
+          </p>
+          <p className="mt-1 font-display text-body font-bold">{doc.title}</p>
+          <p className="mt-0.5 hidden font-mono text-label text-ink-500 sm:block">
+            {doc.docMeta}
+          </p>
+        </div>
+        <p className="shrink-0 font-mono text-label uppercase tracking-[0.085em] text-ink-500">
+          {doc.tag}
+        </p>
+      </div>
+
+      <div className="border-b border-ink-200 py-3">
+        <p className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
+          <span className="font-mono text-label tracking-[0.085em] text-ink-600">
+            {doc.finding.id}
+          </span>
+          <span aria-hidden className="size-1.5 rounded-full bg-brand-700" />
+          <span className="font-mono text-label uppercase tracking-[0.085em] text-brand-700">
+            {doc.finding.severity}
+          </span>
+          <span className="hidden font-mono text-label text-ink-500 sm:inline">
+            {doc.finding.meta}
+          </span>
+        </p>
+        <p className="mt-1.5 font-display text-small font-bold leading-snug">
+          {doc.finding.title}
+        </p>
+      </div>
+
+      <div className="space-y-2.5 pt-3">
+        {rows.map((item) => (
+          <p
+            key={item.label}
+            className={cn(
+              "text-fine leading-relaxed text-ink-700",
+              item.secondary && "hidden sm:block",
+            )}
+          >
+            <strong className="font-medium text-ink-950">{item.label}: </strong>
+            {item.text}
+          </p>
+        ))}
+      </div>
+
+      <p className="mt-4 flex items-center justify-between border-t border-ink-200 pt-2.5 font-mono text-label text-ink-500">
+        <span className="hidden sm:inline">SecurePulse</span>
+        <span>{doc.pageLine}</span>
+      </p>
+    </div>
+  );
+}
+
+/**
+ * The deliverable as a document: its own title, then its contents in order,
+ * ending wherever the content ends — for SecurePulse that is always the
+ * sign-off. Optional attestation rows put the review posture *inside* the
+ * document instead of beside it.
+ */
+export function ReportContents({
+  title,
+  sections,
+  signoff,
+  className,
+}: {
+  title: string;
+  sections: readonly string[];
+  /** Role → state rows, in document-control grammar. */
+  signoff?: {
+    heading: string;
+    rows: readonly { role: string; state: string }[];
+  };
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-card border border-border bg-surface-raised p-5 shadow-[var(--shadow-card)] sm:p-7",
+        className,
+      )}
+    >
+      <p className="border-b border-border-strong pb-3.5 text-heading-2 text-fg sm:pb-4">
+        {title}
+      </p>
+      <ol className="mt-4 space-y-2.5">
+        {sections.map((section, i) => (
+          <li key={section} className="flex items-baseline gap-3">
+            <span className="font-mono text-label text-fg-subtle">
+              {String(i + 1).padStart(2, "0")}
+            </span>
+            {/* `min-w-0` zeroes the flex floor: at a 200% default font size on
+                a 320px screen, "Recommendations" alone is wider than the row,
+                and without the zero it sets the row's width instead of
+                breaking. */}
+            <span className="min-w-0 text-body text-fg-muted">{section}</span>
+            <span
+              aria-hidden
+              className="mb-1 flex-1 self-end border-b border-dotted border-border"
+            />
+          </li>
+        ))}
+      </ol>
+
+      {signoff ? (
+        <div className="mt-5 border-t border-border-strong pt-4">
+          <p className="font-mono text-label uppercase tracking-[0.085em] text-fg-subtle">
+            {signoff.heading}
+          </p>
+          {/* Wrapping flex rather than a two-column grid: at a raised default
+              font size the state ("Your compliance lead") is wider than the
+              card and a rigid column would squeeze the role into vertical
+              rubble — wrapped, it simply takes its own line. */}
+          <dl className="mt-3 space-y-2">
+            {signoff.rows.map((row) => (
+              <div
+                key={row.role}
+                className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-0.5"
+              >
+                <dt className="text-small text-fg-muted">{row.role}</dt>
+                <dd className="text-small text-fg">{row.state}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The assessment summary a report opens with: severity rows and their counts.
+ * The counts are illustrative and the content says so; the shape is the
+ * point — after everything is assessed, leadership receives a scorecard,
+ * not a pile of prose.
+ */
+export function RiskScorecard({
+  title,
+  tag,
+  columns,
+  rows,
+  totals,
+  className,
+}: {
+  title: string;
+  tag: string;
+  columns: { severity: string; count: string };
+  rows: readonly { severity: string; count: string; accent?: boolean }[];
+  totals?: { label: string; value: string };
+  className?: string;
+}) {
+  return (
+    <div className={className}>
+      <h3 className="flex items-baseline gap-3">
+        <span className="text-heading-2 text-fg">{title}</span>
+        <span className="font-mono text-label uppercase tracking-[0.085em] text-fg-subtle">
+          {tag}
+        </span>
+      </h3>
+      <div className="mt-4 overflow-hidden rounded-card border border-border bg-surface-raised shadow-[var(--shadow-card)]">
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-x-5 border-b border-border px-5 py-3">
+          <span className="font-mono text-label uppercase tracking-[0.085em] text-fg-subtle">
+            {columns.severity}
+          </span>
+          <span className="font-mono text-label uppercase tracking-[0.085em] text-fg-subtle">
+            {columns.count}
+          </span>
+        </div>
+        {rows.map((row) => (
+          <div
+            key={row.severity}
+            className="grid grid-cols-[minmax(0,1fr)_auto] items-baseline gap-x-5 border-b border-border px-5 py-2.5 last:border-b-0"
+          >
+            <span
+              className={cn(
+                "text-small",
+                row.accent ? "font-medium text-accent" : "text-fg-muted",
+              )}
+            >
+              {row.severity}
+            </span>
+            <span className="font-mono text-small text-fg">{row.count}</span>
+          </div>
+        ))}
+        {totals ? (
+          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-baseline gap-x-5 border-t border-border-strong px-5 py-2.5">
+            <span className="text-small font-medium text-fg">{totals.label}</span>
+            <span className="font-mono text-small text-fg">{totals.value}</span>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/* ==========================================================================
+   RequirementMap — compliance-mapping grammar, three rows
+   --------------------------------------------------------------------------
+   The report maps every requirement to an authority, an evidence label, its
+   applicability, and a priority. Three rows are enough to show the
+   discipline: one confirmed, one partial, one honest gap — escalated, never
+   assumed. A table from `sm` up; stacked below it.
+   ========================================================================== */
+
+export interface RequirementMapContent {
+  title: string;
+  tag: string;
+  columns: { requirement: string; evidence: string; status: string; priority: string };
+  rows: readonly {
+    requirement: string;
+    evidence: string;
+    status: string;
+    priority: string;
+  }[];
+}
+
+export function RequirementMap({
+  content,
+  className,
+}: {
+  content: RequirementMapContent;
+  className?: string;
+}) {
+  const { title, tag, columns, rows } = content;
+  return (
+    <div className={className}>
+      <h3 className="flex items-baseline gap-3">
+        <span className="text-heading-2 text-fg">{title}</span>
+        <span className="font-mono text-label uppercase tracking-[0.085em] text-fg-subtle">
+          {tag}
+        </span>
+      </h3>
+      <div className="mt-4 overflow-hidden rounded-card border border-border bg-surface-raised shadow-[var(--shadow-card)]">
+        <div className="hidden sm:block">
+          <div className="grid grid-cols-[minmax(0,1.6fr)_minmax(0,0.7fr)_minmax(0,1.3fr)_auto] gap-x-5 border-b border-border px-5 py-3">
+            {[columns.requirement, columns.evidence, columns.status, columns.priority].map(
+              (col) => (
+                <span
+                  key={col}
+                  className="font-mono text-label uppercase tracking-[0.085em] text-fg-subtle"
+                >
+                  {col}
+                </span>
+              ),
+            )}
+          </div>
+          {rows.map((row) => (
+            <div
+              key={row.requirement}
+              className="grid grid-cols-[minmax(0,1.6fr)_minmax(0,0.7fr)_minmax(0,1.3fr)_auto] items-baseline gap-x-5 border-b border-border px-5 py-3.5 last:border-b-0"
+            >
+              <span className="text-small text-fg">{row.requirement}</span>
+              <span className="font-mono text-label uppercase tracking-[0.085em] text-accent">
+                {row.evidence}
+              </span>
+              <span className="text-small text-fg-muted">{row.status}</span>
+              <span className="text-small text-fg">{row.priority}</span>
+            </div>
+          ))}
+        </div>
+
+        {/* Stacked below `sm`: requirement leads, evidence label and priority
+            share the meta line, status follows. */}
+        <ul className="sm:hidden">
+          {rows.map((row) => (
+            <li
+              key={row.requirement}
+              className="space-y-1.5 border-b border-border p-4 last:border-b-0"
+            >
+              <p className="text-small text-fg">{row.requirement}</p>
+              <p className="flex items-baseline gap-3">
+                <span className="font-mono text-label uppercase tracking-[0.085em] text-accent">
+                  {row.evidence}
+                </span>
+                <span className="text-fine text-fg-subtle">{row.priority}</span>
+              </p>
+              <p className="text-fine text-fg-muted">{row.status}</p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/visuals/index.tsx
+++ b/src/components/visuals/index.tsx
@@ -254,6 +254,26 @@ export function withBrand(text: string) {
 }
 
 /* ==========================================================================
+   IndonesiaFlag — the market-designation mark
+   --------------------------------------------------------------------------
+   Two CSS bands rather than the 🇮🇩 emoji, which Windows renders as the
+   letters "ID". Decorative: the visible word "Indonesia" beside it is
+   always the accessible name.
+   ========================================================================== */
+
+export function IndonesiaFlag() {
+  return (
+    <span
+      aria-hidden
+      className="inline-flex h-3 w-[18px] shrink-0 flex-col overflow-hidden rounded-[2px] border border-border-strong"
+    >
+      <span className="h-1/2 bg-merah" />
+      <span className="h-1/2 bg-white" />
+    </span>
+  );
+}
+
+/* ==========================================================================
    Flow — a labelled sequence, optionally splitting at the end
    --------------------------------------------------------------------------
    Used wherever a page describes something moving through stages. One
@@ -319,125 +339,6 @@ export function Flow({
         </ul>
       ) : null}
     </div>
-  );
-}
-
-/* ==========================================================================
-   EvidenceLink — SecurePulse
-   --------------------------------------------------------------------------
-   The product's differentiator in one picture: a finding, and the source it
-   is tied back to. Placeholder text only — never real regulation.
-   ========================================================================== */
-
-export function EvidenceLink({ className }: { className?: string }) {
-  return (
-    <div
-      role="img"
-      aria-label="A draft finding joined by a link to the site photo and authority reference it was drawn from."
-      className={cn(
-        "grid items-center gap-4 sm:grid-cols-[1fr_auto_1fr]",
-        className,
-      )}
-    >
-      <div className="rounded-card border border-border bg-surface-raised p-5">
-        <p className="text-small text-fg-subtle">Finding</p>
-        <p className="mt-2 text-body text-fg">Perimeter lighting not continuous</p>
-        <p className="mt-3 text-small text-fg-muted">Severity: high</p>
-      </div>
-
-      <div aria-hidden className="flex items-center justify-center gap-1 sm:flex-col">
-        <span className="h-px w-8 bg-accent sm:h-8 sm:w-px" />
-        <span className="size-1.5 shrink-0 rounded-full bg-accent" />
-        <span className="h-px w-8 bg-accent sm:h-8 sm:w-px" />
-      </div>
-
-      <div className="rounded-card border border-border bg-surface-raised p-5">
-        <p className="text-small text-fg-subtle">Traced back to</p>
-        <p className="mt-2 text-body text-fg">Site photo, north boundary</p>
-        <p className="mt-3 text-small text-fg-muted">
-          Authority reference, with its evidence label
-        </p>
-      </div>
-    </div>
-  );
-}
-
-/* ==========================================================================
-   StatusList — product panels
-   --------------------------------------------------------------------------
-   A caption, then rows of "what it is" and "where it stands". A dot carries
-   the state and the word names it, so meaning never rests on colour alone.
-   ========================================================================== */
-
-export interface StatusRow {
-  label: string;
-  status: string;
-  /** Reuses PulseDot's tones so the two never drift apart. */
-  tone: "positive" | "attention" | "neutral";
-}
-
-export function StatusList({
-  caption,
-  rows,
-  footnote,
-}: {
-  caption: string;
-  rows: readonly StatusRow[];
-  footnote?: string;
-}) {
-  return (
-    <div className="p-6">
-      <p className="text-small text-fg-subtle">{caption}</p>
-
-      <ul className="mt-5 space-y-4">
-        {rows.map((row, i) => (
-          <li
-            key={row.label}
-            className="grid grid-cols-[1fr_auto] items-baseline gap-4"
-          >
-            <span className="text-body text-fg">{row.label}</span>
-            <span className="flex w-[7.5rem] items-center gap-2 text-small text-fg-muted">
-              <PulseDot tone={row.tone} delay={i * 320} />
-              {row.status}
-            </span>
-          </li>
-        ))}
-      </ul>
-
-      {footnote ? (
-        <p className="mt-6 border-t border-border pt-4 text-fine text-fg-subtle">
-          {footnote}
-        </p>
-      ) : null}
-    </div>
-  );
-}
-
-export function AssessmentPanel() {
-  return (
-    <StatusList
-      caption="Draft findings"
-      rows={[
-        { label: "Perimeter security", status: "Verified", tone: "positive" },
-        { label: "Access control", status: "Partial", tone: "neutral" },
-        { label: "Supply chain & delivery", status: "Gap", tone: "attention" },
-      ]}
-      footnote="Signed off by a named assessor before it becomes a report."
-    />
-  );
-}
-
-export function CallOutcomeList() {
-  return (
-    <StatusList
-      caption="Call outcomes"
-      rows={[
-        { label: "Budget confirmed", status: "Qualified", tone: "positive" },
-        { label: "Call back next week", status: "Callback", tone: "attention" },
-        { label: "Outside the area", status: "Not qualified", tone: "neutral" },
-      ]}
-      footnote="Only the qualified conversations reach your team."
-    />
   );
 }
 

--- a/src/components/visuals/topology.tsx
+++ b/src/components/visuals/topology.tsx
@@ -1,0 +1,112 @@
+import { cn } from "@/lib/utils";
+import { PulseDot } from "@/components/visuals";
+
+/* ==========================================================================
+   SystemTopology — the shape of the commissioned platform
+   --------------------------------------------------------------------------
+   An anonymised but truthful structure: the trade path as a spine, the
+   verification gate feeding it, and the operator console underneath every
+   stage — because that is where the accuracy the page talks about is
+   actually maintained. Built from the site's flow grammar (dots, thin
+   rules, one accent) so it reads as a system diagram, not a marketing
+   graphic. Stacks into a single column on phones.
+   ========================================================================== */
+
+export interface TopologyContent {
+  /** The admission control that sits in front of trading. */
+  gate: { label: string; note: string };
+  stages: readonly { label: string; note: string }[];
+  /** The judgment seat. Carries the accent. */
+  console: { label: string; note: string };
+  /** Accessible description of the whole structure. */
+  alt: string;
+}
+
+function GateChip({ gate }: { gate: TopologyContent["gate"] }) {
+  return (
+    <>
+      <p className="inline-flex items-center rounded-control border border-border-strong px-3 py-1.5 text-small text-fg-muted">
+        {gate.label}
+      </p>
+      <p className="mt-1 max-w-[26ch] text-fine text-fg-subtle">{gate.note}</p>
+      {/* A dashed feed line: admission is a check, not a stage. */}
+      <span
+        aria-hidden
+        className="ml-1 mt-2 block h-5 w-px border-l border-dashed border-border-strong"
+      />
+    </>
+  );
+}
+
+export function SystemTopology({
+  content,
+  className,
+}: {
+  content: TopologyContent;
+  className?: string;
+}) {
+  const cols = content.stages.length;
+  return (
+    <div role="img" aria-label={content.alt} className={cn("w-full", className)}>
+      {/* The gate joins the spine ahead of trading: over its column on a
+          desktop, at the top of the single column on a phone. */}
+      <div
+        className="hidden sm:grid sm:gap-x-4"
+        style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
+      >
+        <div className="col-start-2">
+          <GateChip gate={content.gate} />
+        </div>
+      </div>
+      <div className="sm:hidden">
+        <GateChip gate={content.gate} />
+      </div>
+
+      {/* The trade path. Same grammar as every flow on the site. */}
+      <ol
+        className="grid gap-x-4 gap-y-6"
+        style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
+      >
+        {content.stages.map((s, i) => (
+          <li key={s.label} className="col-span-full sm:col-span-1">
+            <div aria-hidden className="flex items-center">
+              <span className="size-2 shrink-0 rounded-full bg-border-strong" />
+              <span
+                className={cn(
+                  "hidden h-px flex-1 sm:block",
+                  i === cols - 1 ? "bg-transparent" : "bg-border-strong",
+                )}
+              />
+            </div>
+            <p className="mt-3 text-body font-medium text-fg">{s.label}</p>
+            <p className="mt-1 max-w-[28ch] text-small text-fg-subtle">{s.note}</p>
+          </li>
+        ))}
+      </ol>
+
+      {/* Risers: every stage reports down into the console. One on a phone. */}
+      <div
+        className="mt-5 hidden sm:grid sm:gap-x-4"
+        style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
+      >
+        {content.stages.map((s) => (
+          <span
+            key={s.label}
+            aria-hidden
+            className="ml-1 block h-6 w-px bg-border-strong"
+          />
+        ))}
+      </div>
+      <span aria-hidden className="ml-1 mt-4 block h-6 w-px bg-border-strong sm:hidden" />
+
+      {/* The console under all of it — the accented seat. */}
+      <div className="rounded-card border border-border-strong bg-surface-raised px-5 py-4 sm:px-6">
+        <p className="flex items-center gap-2.5 text-body font-medium text-fg">
+          <PulseDot tone="accent" size="md" halo />
+          {content.console.label}
+        </p>
+        <p className="mt-1.5 text-small text-fg-muted">{content.console.note}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/content/home.ts
+++ b/src/content/home.ts
@@ -89,6 +89,13 @@ export const PRODUCTS = {
       accent: false,
     },
   ],
+  /** The Indonesian deployment, discoverable without a detour: one line
+   *  under the SecurePulse panel, marked with the market flag. */
+  securepulseMarket: {
+    note: "Also deployed for Indonesian financial institutions",
+    label: "SecurePulse Indonesia",
+    href: "/securepulse/indonesia",
+  },
 } as const;
 
 export const COMMISSIONED = {

--- a/src/content/indonesia/en.ts
+++ b/src/content/indonesia/en.ts
@@ -224,6 +224,14 @@ export const EN: IndoContent = {
         "Compliance mapping",
         "Reviewer sign-off",
       ],
+      signoff: {
+        heading: "Sign-off",
+        rows: [
+          { role: "Prepared by", state: "SecurePulse — draft" },
+          { role: "Verified by", state: "Your reviewer" },
+          { role: "Approved by", state: "Your compliance lead" },
+        ],
+      },
     },
   },
   comparison: {

--- a/src/content/indonesia/id.ts
+++ b/src/content/indonesia/id.ts
@@ -221,6 +221,14 @@ export const ID: IndoContent = {
         "Pemetaan kepatuhan",
         "Pengesahan penelaah",
       ],
+      signoff: {
+        heading: "Pengesahan",
+        rows: [
+          { role: "Disusun oleh", state: "SecurePulse — draf" },
+          { role: "Diverifikasi oleh", state: "Penelaah Anda" },
+          { role: "Disetujui oleh", state: "Pimpinan kepatuhan Anda" },
+        ],
+      },
     },
   },
   comparison: {

--- a/src/content/indonesia/types.ts
+++ b/src/content/indonesia/types.ts
@@ -135,6 +135,12 @@ export interface IndoContent {
     report: {
       title: string;
       sections: readonly string[];
+      /** Attestation rows, in the report's own document-control grammar:
+       *  the draft is SecurePulse's, the verification is the customer's. */
+      signoff: {
+        heading: string;
+        rows: readonly { role: string; state: string }[];
+      };
     };
   };
   comparison: {

--- a/src/content/kai.ts
+++ b/src/content/kai.ts
@@ -14,6 +14,47 @@ export const KAI_HERO = {
   secondary: { label: "Start a conversation", href: "/contact?topic=kai" },
 } as const;
 
+/**
+ * The hero visual: one call, mid-conversation. The transcript, the
+ * structured answers extracted from it, and the classification it ends in —
+ * kAI's whole workflow in the product's own material. Illustrative dialogue;
+ * no real lead, no real campaign.
+ */
+export const KAI_CALL_PANEL = {
+  alt: "Illustrative outbound qualification call in progress: kAI asks scripted questions, the lead answers, the answers become structured fields — budget confirmed, timeline this quarter, decision-maker on the call — and the conversation is classified as qualified and routed to the team.",
+  context: "Outbound call · your number",
+  state: "In conversation · 02:41",
+  transcript: [
+    {
+      speaker: "kAI",
+      agent: true,
+      text: "Is there a budget already approved for this?",
+    },
+    {
+      speaker: "Lead",
+      text: "Yes — sign-off came through this quarter.",
+    },
+    {
+      speaker: "kAI",
+      agent: true,
+      text: "And who would be involved in the decision?",
+      secondary: true,
+    },
+    {
+      speaker: "Lead",
+      text: "That's me, with our operations lead.",
+      secondary: true,
+    },
+  ],
+  answersLabel: "Structured answers",
+  answers: [
+    { field: "Budget", value: "Confirmed" },
+    { field: "Timeline", value: "This quarter" },
+    { field: "Decision-maker", value: "On the call" },
+  ],
+  outcome: "Qualified — routed to your team",
+} as const;
+
 export const KAI_WORKFLOW = {
   heading: "Your process, before a single call goes out.",
   steps: [

--- a/src/content/securepulse.ts
+++ b/src/content/securepulse.ts
@@ -19,6 +19,47 @@ export const SP_HERO = {
   cta: { label: "Talk to us about SecurePulse", href: "/contact?topic=securepulse" },
 } as const;
 
+/**
+ * The hero visual: one page of the report SecurePulse actually produces,
+ * structured after the real deliverable's detailed-finding anatomy. The
+ * facility is anonymised the way a published excerpt would be — no client,
+ * no authority named inside the mockup — and the corner tag marks it
+ * illustrative.
+ */
+export const SP_HERO_PANEL = {
+  alt: "Illustrative detailed-finding page from a SecurePulse physical security assessment of an anonymised Dubai energy-sector facility: a high-severity finding that perimeter CCTV was asserted as operational without retention or test evidence, with what was observed, the risk, the immediate remediation, and the reviewer state.",
+  tag: "Illustrative",
+  institution: "Energy-sector facility · Dubai",
+  title: "Physical security assessment",
+  docMeta: "Draft 1.0 · For management review",
+  finding: {
+    id: "F-07",
+    severity: "High",
+    title: "Perimeter CCTV asserted as operational, but retention and test records not evidenced",
+    meta: "Surveillance & monitoring · 8 points",
+  },
+  body: [
+    {
+      label: "What we observed",
+      text: "The checklist records continuous perimeter coverage across twelve cameras on the north boundary; no retention settings, alarm-test reports, or maintenance records were attached to evidence it.",
+    },
+    {
+      label: "Risk",
+      text: "Unevidenced surveillance cannot support management reliance — or an incident investigation.",
+      secondary: true,
+    },
+    {
+      label: "Remediation",
+      text: "Immediate — attach retention settings and the latest alarm-test report; re-verify within 30 days.",
+    },
+    {
+      label: "Reviewer",
+      text: "Pending sign-off.",
+    },
+  ],
+  pageLine: "Detailed findings · 6 / 14",
+} as const;
+
 export const SP_JURISDICTION = {
   heading: "In the UAE, location decides the rulebook.",
   body: [
@@ -102,6 +143,43 @@ export const SP_EVIDENCE = {
   ],
 } as const;
 
+/**
+ * The compliance-mapping grammar from the report itself: requirement,
+ * evidence label, where it stands, and its priority. Three rows show the
+ * discipline — one confirmed, one partial, one honest gap. Anonymised:
+ * authorities are described, never named, inside a mockup.
+ */
+export const SP_MAPPING = {
+  title: "Requirement mapping",
+  tag: "Illustrative",
+  columns: {
+    requirement: "Requirement",
+    evidence: "Evidence",
+    status: "Standing",
+    priority: "Priority",
+  },
+  rows: [
+    {
+      requirement: "Continuous perimeter lighting at the site boundary",
+      evidence: "VERIFIED",
+      status: "Applies to the site — confirmed from the authority's enacted framework",
+      priority: "High",
+    },
+    {
+      requirement: "CCTV retention minimums for restricted areas",
+      evidence: "PARTIAL",
+      status: "Applies — technical minimums to be confirmed against the current manual",
+      priority: "Medium",
+    },
+    {
+      requirement: "Operator-specific design standards",
+      evidence: "GAP",
+      status: "Unresolved — escalated to the competent authority, not assumed",
+      priority: "High",
+    },
+  ],
+} as const;
+
 export const SP_HUMAN = {
   heading: "SecurePulse drafts. People decide.",
   body: [
@@ -112,23 +190,67 @@ export const SP_HUMAN = {
 
 export const SP_REPORT = {
   heading: "A report a consultant would recognise.",
-  body: "SecurePulse produces the sections an assessment report is expected to contain, in a consistent structure, exportable to PDF or Word.",
-  sections: [
-    "Assessment summary and risk scorecard",
-    "Findings by domain",
-    "Detailed findings with severity",
-    "Risk matrix",
-    "Compensating controls for critical and high findings",
-    "Indicative compliance mapping",
-    "Prioritised recommendations roadmap",
-    "Assumptions, information gaps, and appendices",
-    "Named sign-off and attestation",
-  ],
+  body: "After the walk, the checklist, and the review, leadership receives a document — the sections an assessment report is expected to contain, in a consistent structure, exportable to PDF or Word.",
+  contents: {
+    title: "Physical security assessment report",
+    sections: [
+      "Assessment summary and risk scorecard",
+      "Findings by domain",
+      "Detailed findings with severity",
+      "Risk matrix",
+      "Compensating controls",
+      "Indicative compliance mapping",
+      "Recommendations roadmap",
+      "Assumptions and information gaps",
+      "Sign-off and attestation",
+    ],
+    signoff: {
+      heading: "Sign-off",
+      rows: [
+        { role: "Prepared by", state: "SecurePulse — draft" },
+        { role: "Lead assessor", state: "Named sign-off" },
+        { role: "Reviewer", state: "Approved for issue" },
+      ],
+    },
+  },
+  scorecard: {
+    title: "Risk scorecard",
+    tag: "Illustrative",
+    columns: { severity: "Severity", count: "Findings" },
+    rows: [
+      { severity: "Critical", count: "0" },
+      { severity: "High", count: "2", accent: true },
+      { severity: "Medium", count: "1" },
+      { severity: "Low", count: "0" },
+      { severity: "Informational", count: "1" },
+    ],
+    totals: { label: "Weighted risk points", value: "21" },
+  },
 } as const;
 
-export const SP_INDONESIA = {
-  body: "SecurePulse is also being prepared for Indonesian banks, fintechs, insurers and other regulated financial institutions — with a dedicated experience in English and Bahasa Indonesia.",
-  cta: { label: "SecurePulse for Indonesia", href: "/securepulse/indonesia" },
+/**
+ * Where SecurePulse runs. The UAE positioning stays this page's claim; the
+ * Indonesian financial-sector deployment is a separate experience and the
+ * two must not blur into one — but a buyer on this page should discover it
+ * without already knowing the URL.
+ */
+export const SP_MARKETS = {
+  heading: "Two markets, one discipline.",
+  markets: [
+    {
+      name: "UAE & Gulf",
+      domain: "Physical security assessment",
+      note: "Emirate- and sector-aware site assessments for energy and government facilities. This page.",
+    },
+    {
+      name: "Indonesia",
+      domain: "Financial-institution compliance",
+      note: "AI-assisted regulatory compliance assessment for banks, fintechs and insurers — in English and Bahasa Indonesia.",
+      href: "/securepulse/indonesia",
+      cta: "SecurePulse Indonesia",
+      flag: true,
+    },
+  ],
 } as const;
 
 export const SP_STATUS = {

--- a/src/content/work.ts
+++ b/src/content/work.ts
@@ -27,42 +27,41 @@ export const WORK_LUXURY = {
     { value: "Live", label: "In commercial use" },
   ],
   lifecycleTitle: "How a trade moves through it",
+  /** Labels only: the topology above already describes each subsystem, so
+   *  the lifecycle reads as one clean line rather than repeating the notes. */
   lifecycle: [
-    { label: "Listed", note: "A unique item, priced on its own merits." },
-    { label: "Bid or offered", note: "A timed auction, or a private negotiation." },
-    { label: "Parties verified", note: "Identity and trade licence checked before money moves." },
-    { label: "Paid", note: "Recorded against a ledger rather than inferred." },
-    { label: "Fulfilled", note: "Tracked to delivery, and after-sale service.", accent: true },
+    { label: "Listed" },
+    { label: "Bid or offered" },
+    { label: "Parties verified" },
+    { label: "Paid" },
+    { label: "Fulfilled", accent: true },
   ],
   scopeTitle: "What the system does",
   scopeIntro:
-    "Described at the level of capability rather than implementation, the platform covers:",
-  scope: [
-    {
-      title: "Multi-sided trading",
-      body: "Listing, buying, and selling high-value individual items, each of which is unique and priced accordingly.",
+    "Described at the level of structure rather than implementation — nothing here identifies the client, and everything here runs in production.",
+  /**
+   * The anonymised shape of the platform. Truthful at the level of
+   * structure — a trade spine, a verification gate in front of trading, an
+   * operator console under everything — with nothing that identifies the
+   * client or the category.
+   */
+  topology: {
+    alt: "System structure: a verification gate admits participants into a trade path running from catalogue through auctions and offers to orders, ledger and fulfilment — with the operator console connected beneath every stage.",
+    gate: {
+      label: "Verified participants",
+      note: "Identity and trade licence checked before a trade opens.",
     },
-    {
-      title: "Auctions and offers",
-      body: "Timed auctions with live bidding, alongside private offers and negotiation between parties.",
+    stages: [
+      { label: "Catalogue", note: "Unique items, each priced on its own merits." },
+      { label: "Auctions & offers", note: "Timed bidding and private negotiation." },
+      { label: "Orders & ledger", note: "Money movement recorded, not inferred." },
+      { label: "Fulfilment", note: "Tracked to delivery and after-sale service." },
+    ],
+    console: {
+      label: "Operator console",
+      note: "The administrative seat where accuracy is maintained day to day — connected to every stage above.",
     },
-    {
-      title: "Payments and balances",
-      body: "Order and payment flows with a transaction ledger, so money movement is recorded rather than inferred.",
-    },
-    {
-      title: "Verified participants",
-      body: "Identity and trade-licence verification with a review queue, because at these values it matters who is on the other side of a trade.",
-    },
-    {
-      title: "Order lifecycle",
-      body: "Purchases tracked from agreement to fulfilment, including after-sale service requests.",
-    },
-    {
-      title: "Operator tooling",
-      body: "An administrative console for the people who run the business day to day, which is where the accuracy is actually maintained.",
-    },
-  ],
+  },
   responsibilityTitle: "Why it mattered",
   responsibility: [
     "A platform like this has more than one way to be expensive. A pricing or availability error is visible to a buyer immediately. A failed payment path strands a transaction worth more than most annual salaries. A weak verification step lets the wrong counterparty into a trade.",


### PR DESCRIPTION
Brings the whole site to the standard set by the SecurePulse Indonesia work: real work-product artifacts, four distinguishable surfaces, and an energetic primary-action orange over the oxide environment.

## By route
- **/securepulse** — report-excerpt hero on paper (anonymised Dubai energy facility, Illustrative), requirement-mapping artifact in the evidence section, paper deliverables section (report contents + sign-off + illustrative risk scorecard), and a two-market block that makes the Indonesian deployment discoverable.
- **/kai** — the hero is now an outbound call mid-conversation: speaker-tagged transcript, structured answers, classification. Workflow moves to coal.
- **/** — products and company sections move to coal; the product cards carry each product's own material (compact report excerpt vs compact call panel); one-line Indonesia discovery under the SecurePulse card.
- **/work** — anonymised system topology (verification gate, trade spine, operator console) replaces the bare capability list; scope section moves to coal.
- **/securepulse/indonesia + /id/…** — the deliverable card gains the report's own sign-off rows in both locales; document components move to a shared module.
- **Global** — primary CTAs return to brand-600 with white text (~4.6:1 AA); oxide remains the environment; ember keeps its white reversal.

## QA
- 344 Playwright checks pass on WebKit and Chromium, including the 320px/200%-text reflow suite (one real defect found and fixed: report-TOC flex floor).
- Desktop + 390/320 visual passes on every changed route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)