### PR TITLE
Flatten the homepage product cards to one hierarchy step

### DIFF
--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -169,7 +169,7 @@ export default function HomePage() {
                 <ProductCard
                   {...PRODUCTS.items[0]}
                   visual={
-                    <VisualFrame label={SP_HERO_PANEL.alt}>
+                    <VisualFrame label={SP_HERO_PANEL.cardAlt}>
                       <FindingDocument doc={SP_HERO_PANEL} compact />
                     </VisualFrame>
                   }
@@ -195,7 +195,7 @@ export default function HomePage() {
                 <ProductCard
                   {...PRODUCTS.items[1]}
                   visual={
-                    <VisualFrame label={KAI_CALL_PANEL.alt}>
+                    <VisualFrame label={KAI_CALL_PANEL.cardAlt}>
                       <CallPanel content={KAI_CALL_PANEL} compact />
                     </VisualFrame>
                   }

--- a/src/components/modules/index.tsx
+++ b/src/components/modules/index.tsx
@@ -72,7 +72,6 @@ export function FitList({
 
 export function ProductCard({
   name,
-  category,
   headline,
   body,
   href,
@@ -80,7 +79,6 @@ export function ProductCard({
   className,
 }: {
   name: string;
-  category: string;
   headline: string;
   body: string;
   href: string;
@@ -93,21 +91,20 @@ export function ProductCard({
           so the eye counts one edge instead of two. */}
       <div className="flex h-full flex-col">
         <div className="flex items-start justify-between gap-4">
-          <div>
-            {/* The product name is the thing being introduced, so it is the
-                largest type here — the tagline supports it, not the reverse. */}
-            <h3 className="text-heading-1 font-medium text-fg">
-              {name === "SecurePulse" ? <SecurePulseName animate /> : name}
-            </h3>
-            <p className="mt-1 text-small text-fg-subtle">{category}</p>
-          </div>
+          {/* The product name is the thing being introduced, so it is the
+              largest type here. No category tagline: the headline right
+              under it is the first descriptive level — one hierarchy step,
+              not two. */}
+          <h3 className="text-heading-1 font-medium text-fg">
+            {name === "SecurePulse" ? <SecurePulseName animate /> : name}
+          </h3>
           <ArrowUpRight
             aria-hidden
             className="mt-1 size-5 shrink-0 text-fg-subtle transition-[color,transform] duration-150 group-hover:text-accent motion-safe:group-hover:-translate-y-0.5 motion-safe:group-hover:translate-x-0.5"
           />
         </div>
 
-        <p className="mt-6 text-lead font-medium text-fg">{headline}</p>
+        <p className="mt-4 text-lead font-medium text-fg">{headline}</p>
         <Text size="small" className="mt-3 max-w-prose">
           {body}
         </Text>

--- a/src/components/visuals/call.tsx
+++ b/src/components/visuals/call.tsx
@@ -42,9 +42,13 @@ export function CallPanel({
 }) {
   return (
     <div className={cn("p-5", !compact && "sm:p-6")}>
-      {/* Call header: where it runs, and that it is running. */}
+      {/* Call header: where it runs, and that it is running. The compact
+          teaser keeps only the live state — the card copy beside it already
+          says whose number the calls run on. */}
       <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 border-b border-border pb-3">
-        <p className="text-small text-fg-subtle">{content.context}</p>
+        {!compact ? (
+          <p className="text-small text-fg-subtle">{content.context}</p>
+        ) : null}
         <p className="flex items-center gap-2 font-mono text-label text-fg-muted">
           <PulseDot tone="live" />
           {content.state}
@@ -78,12 +82,15 @@ export function CallPanel({
         ))}
       </ul>
 
-      {/* What the speech became: structured answers, not a recording. */}
+      {/* What the speech became: structured answers, not a recording. In the
+          compact teaser the field/value pairs say it without a heading. */}
       <div className="mt-4 border-t border-border pt-3.5">
-        <p className="font-mono text-label uppercase tracking-[0.085em] text-fg-subtle">
-          {content.answersLabel}
-        </p>
-        <dl className="mt-2.5 flex flex-wrap gap-x-6 gap-y-1.5">
+        {!compact ? (
+          <p className="mb-2.5 font-mono text-label uppercase tracking-[0.085em] text-fg-subtle">
+            {content.answersLabel}
+          </p>
+        ) : null}
+        <dl className="flex flex-wrap gap-x-6 gap-y-1.5">
           {content.answers.map((a) => (
             <div key={a.field} className="flex items-baseline gap-2">
               <dt className="text-fine text-fg-subtle">{a.field}</dt>

--- a/src/components/visuals/document.tsx
+++ b/src/components/visuals/document.tsx
@@ -39,9 +39,11 @@ export interface FindingDocumentContent {
  * detailed finding in the report's own anatomy. Rendered inside a
  * `VisualFrame`, which carries the accessible description.
  *
- * `compact` is the product-card excerpt: header, the severity-headed
- * finding, and the reviewer state — the material without the prose, so the
- * card stays a teaser and the product page keeps the full page to itself.
+ * `compact` is the product-card excerpt: the context line, the
+ * severity-headed finding, and the reviewer state — the material without
+ * the document's own subtitle, version line or scoring metadata, so the
+ * card reads in a glance and the product page keeps the full page to
+ * itself.
  */
 export function FindingDocument({
   doc,
@@ -58,10 +60,14 @@ export function FindingDocument({
           <p className="font-mono text-label uppercase tracking-[0.085em] text-ink-600">
             {doc.institution}
           </p>
-          <p className="mt-1 font-display text-body font-bold">{doc.title}</p>
-          <p className="mt-0.5 hidden font-mono text-label text-ink-500 sm:block">
-            {doc.docMeta}
-          </p>
+          {!compact ? (
+            <>
+              <p className="mt-1 font-display text-body font-bold">{doc.title}</p>
+              <p className="mt-0.5 hidden font-mono text-label text-ink-500 sm:block">
+                {doc.docMeta}
+              </p>
+            </>
+          ) : null}
         </div>
         <p className="shrink-0 font-mono text-label uppercase tracking-[0.085em] text-ink-500">
           {doc.tag}
@@ -77,9 +83,11 @@ export function FindingDocument({
           <span className="font-mono text-label uppercase tracking-[0.085em] text-brand-700">
             {doc.finding.severity}
           </span>
-          <span className="hidden font-mono text-label text-ink-500 sm:inline">
-            {doc.finding.meta}
-          </span>
+          {!compact ? (
+            <span className="hidden font-mono text-label text-ink-500 sm:inline">
+              {doc.finding.meta}
+            </span>
+          ) : null}
         </p>
         <p className="mt-1.5 font-display text-small font-bold leading-snug">
           {doc.finding.title}

--- a/src/content/home.ts
+++ b/src/content/home.ts
@@ -74,19 +74,15 @@ export const PRODUCTS = {
   items: [
     {
       name: "SecurePulse",
-      category: "Physical security assessment",
       headline: "Site assessments that show their working.",
-      body: "SecurePulse turns a physical security inspection into a structured assessment: a checklist built for the site's emirate and sector, photo evidence captured on the walk, and findings graded by severity. Every regulatory reference carries an evidence label, and a named assessor signs the report off.",
+      body: "SecurePulse turns a physical security inspection into a structured, evidence-backed assessment: a checklist built for the site's emirate and sector, photo evidence captured on the walk, and findings graded by severity. A named assessor signs the report off.",
       href: "/securepulse",
-      accent: true,
     },
     {
       name: "kAI",
-      category: "Outbound voice agent",
       headline: "Calls the list. Flags the ones worth your time.",
       body: "kAI runs outbound qualification calls on your own number, follows the script your team agreed, and classifies each conversation so your people spend their hours on the leads that justify them.",
       href: "/kai",
-      accent: false,
     },
   ],
   /** The Indonesian deployment, discoverable without a detour: one line

--- a/src/content/kai.ts
+++ b/src/content/kai.ts
@@ -22,6 +22,9 @@ export const KAI_HERO = {
  */
 export const KAI_CALL_PANEL = {
   alt: "Illustrative outbound qualification call in progress: kAI asks scripted questions, the lead answers, the answers become structured fields — budget confirmed, timeline this quarter, decision-maker on the call — and the conversation is classified as qualified and routed to the team.",
+  /** The homepage teaser: one exchange, the extracted fields, the outcome. */
+  cardAlt:
+    "Illustrative live qualification call: kAI asks about budget, the lead confirms, the answers become structured fields, and the call is classified as qualified and routed to the team.",
   context: "Outbound call · your number",
   state: "In conversation · 02:41",
   transcript: [

--- a/src/content/securepulse.ts
+++ b/src/content/securepulse.ts
@@ -28,6 +28,9 @@ export const SP_HERO = {
  */
 export const SP_HERO_PANEL = {
   alt: "Illustrative detailed-finding page from a SecurePulse physical security assessment of an anonymised Dubai energy-sector facility: a high-severity finding that perimeter CCTV was asserted as operational without retention or test evidence, with what was observed, the risk, the immediate remediation, and the reviewer state.",
+  /** The homepage teaser shows the excerpt without the prose. */
+  cardAlt:
+    "Illustrative excerpt of a SecurePulse assessment report for an anonymised Dubai energy-sector facility: a high-severity finding that perimeter CCTV was asserted as operational without retention or test evidence, awaiting reviewer sign-off.",
   tag: "Illustrative",
   institution: "Energy-sector facility · Dubai",
   title: "Physical security assessment",


### PR DESCRIPTION
Homepage-only cleanup after founder review of production: the product cards drop their category descriptors so the headline is the first descriptive level, and the compact teaser visuals shed secondary metadata (document subtitle/version/points; call context line and answers heading) so each panel communicates in a glance. Full /securepulse and /kai visuals unchanged.

QA: 344 Playwright checks pass on WebKit + Chromium; desktop and 390px visual passes; no horizontal overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)