### PR TITLE
Align SecurePulse output icons with their labels

### DIFF
--- a/src/components/indonesia/visuals.tsx
+++ b/src/components/indonesia/visuals.tsx
@@ -95,7 +95,13 @@ export function IconList({
       {items.map((item) => {
         const Icon = ICONS[item.icon];
         return (
-          <li key={item.label} className="flex items-start gap-3 sm:gap-3.5">
+          <li
+            key={item.label}
+            className={cn(
+              "flex gap-3 sm:gap-3.5",
+              emphasis ? "items-center" : "items-start",
+            )}
+          >
             <span
               aria-hidden
               className={cn(
@@ -107,7 +113,7 @@ export function IconList({
             >
               <Icon className="size-4" />
             </span>
-            <span className="min-w-0 pt-1.5">
+            <span className={cn("min-w-0", !emphasis && "pt-1.5")}>
               <span className={cn("block text-body", emphasis ? "text-fg" : "text-fg-muted")}>
                 {item.label}
               </span>

--- a/tests/mobile.spec.ts
+++ b/tests/mobile.spec.ts
@@ -217,6 +217,37 @@ test.describe("home: hero visualisation to the block beneath it", () => {
    ========================================================================== */
 
 test.describe("layout", () => {
+  test("SecurePulse output icons stay centred on wrapped and single-line labels", async ({ page }) => {
+    for (const route of ["/securepulse/indonesia", "/id/securepulse/indonesia"]) {
+      for (const width of [404, 1440]) {
+        await page.setViewportSize({ width, height: 900 });
+        await page.goto(route);
+        await settle(page);
+
+        const deltas = await page.evaluate(() => {
+          const headings = [...document.querySelectorAll("main h3")];
+          const heading = headings.find((el) =>
+            /(?:SecurePulse produces|Yang dihasilkan SecurePulse)/.test(el.textContent ?? ""),
+          );
+          const rows = heading?.parentElement?.querySelectorAll("li") ?? [];
+
+          return [...rows].map((row) => {
+            const icon = row.children[0]?.getBoundingClientRect();
+            const label = row.children[1]?.getBoundingClientRect();
+            if (!icon || !label) return Number.POSITIVE_INFINITY;
+            return Math.abs(icon.top + icon.height / 2 - (label.top + label.height / 2));
+          });
+        });
+
+        expect(deltas, `${route} at ${width}px has no output rows`).not.toHaveLength(0);
+        expect(
+          Math.max(...deltas),
+          `${route} output icon and label centres drift at ${width}px`,
+        ).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
   for (const vp of [...PHONES, ...LANDSCAPE]) {
     for (const route of ROUTES) {
       test(`${route} at ${vp.name}: no horizontal overflow, every section visible`, async ({


### PR DESCRIPTION
## Summary
- vertically center SecurePulse deliverable icons against their full label block
- preserve the existing top alignment for the input list, including its explanatory note
- cover English and Indonesian output rows at 404px mobile and 1440px desktop

## Verification
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test:e2e (346 passing across Chromium and WebKit)
- Vercel development deployment completed successfully